### PR TITLE
feat: add tree-sitter-ini support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [html](https://github.com/tree-sitter/tree-sitter-html) - MIT License
 - [hyprlang](https://github.com/tree-sitter-grammars/tree-sitter-hyprlang) - MIT License
 - [ispc](https://github.com/tree-sitter-grammars/tree-sitter-ispc) - MIT License
+- [ini](https://github.com/justinmk/tree-sitter-ini) - Apache License 2.0
 - [janet](https://github.com/GrayJack/tree-sitter-janet) - BSD-3-Clause license
 - [java](https://github.com/tree-sitter/tree-sitter-java) - MIT License
 - [javascript](https://github.com/tree-sitter/tree-sitter-javascript) - MIT License

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -280,6 +280,11 @@
     "repo": "https://github.com/tree-sitter-grammars/tree-sitter-hyprlang",
     "rev": "d719158abe537b1916daaea6fa03287089f0b601"
   },
+  "ini": {
+    "branch": "master",
+    "repo": "https://github.com/justinmk/tree-sitter-ini",
+    "rev": "31899dfa3b91622ea39e5c0bcddc88f45a9a3cfe"
+  },
   "ispc": {
     "repo": "https://github.com/tree-sitter-grammars/tree-sitter-ispc",
     "rev": "9b2f9aec2106b94b4e099fe75e73ebd8ae707c04"

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -76,6 +76,7 @@ SupportedLanguage = Literal[
     "hlsl",
     "html",
     "hyprlang",
+    "ini",
     "ispc",
     "janet",
     "java",


### PR DESCRIPTION
Add support to .ini parser from [justinmk/tree-sitter-ini](https://github.com/justinmk/tree-sitter-ini)

(Apache-2.0 license)