### PR TITLE
feat: add get_supported_languages() to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ pip install tree-sitter-language-pack
 
 ## Usage
 
-This library exposes three functions: `get_binding`, `get_language`, and `get_parser`.
+This library exposes four functions: `get_binding`, `get_language`, `get_parser`, and `get_supported_languages`.
 
 ```python
-from tree_sitter_language_pack import get_binding, get_language, get_parser
+from tree_sitter_language_pack import get_binding, get_language, get_parser, get_supported_languages
 
 python_binding = get_binding("python")  # this is a pycapsule object pointing to the C binding
 python_lang = get_language("python")  # this is an instance of tree_sitter.Language
 python_parser = get_parser("python")  # this is an instance of tree_sitter.Parser
+supported_languages = get_supported_languages()  # a tuple of all supported language name strings
 ```
 
 See the list of available languages below to get the name of the language you want to use.

--- a/tests/entry_point_test.py
+++ b/tests/entry_point_test.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from tree_sitter import Language, Parser
 
-from tree_sitter_language_pack import SupportedLanguage, get_binding, get_language, get_parser
+from tree_sitter_language_pack import SupportedLanguage, get_binding, get_language, get_parser, get_supported_languages
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -33,8 +33,20 @@ language_names = sorted([*list(language_definitions.keys()), "yaml", "csharp", "
 
 
 def test_language_names() -> None:
-    supported_languages = sorted(SupportedLanguage.__args__)  # type: ignore[attr-defined]
+    supported_languages = sorted(get_supported_languages())
     assert supported_languages == language_names
+
+
+def test_get_supported_languages() -> None:
+    languages = get_supported_languages()
+    assert isinstance(languages, tuple)
+    assert len(languages) > 0
+    assert all(isinstance(lang, str) for lang in languages)
+
+
+@pytest.mark.parametrize("language", language_names)
+def test_get_supported_languages_contains(language: str) -> None:
+    assert language in get_supported_languages()
 
 
 @pytest.mark.parametrize("language", language_names)

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -4,7 +4,7 @@ import ctypes
 import sys
 from importlib import import_module
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal, cast, get_args
 
 import tree_sitter_c_sharp
 import tree_sitter_embedded_template
@@ -187,6 +187,8 @@ SupportedLanguage = Literal[
     "magik",
 ]
 
+_SUPPORTED_LANGUAGES: tuple[str, ...] = get_args(SupportedLanguage)
+
 
 def get_binding(language_name: SupportedLanguage) -> object:
     """Get the binding for the given language name.
@@ -254,4 +256,13 @@ def get_parser(language_name: SupportedLanguage) -> Parser:
     return Parser(get_language(language_name=language_name))
 
 
-__all__ = ["SupportedLanguage", "get_binding", "get_language", "get_parser"]
+def get_supported_languages() -> tuple[str, ...]:
+    """Get a tuple of all supported language names.
+
+    Returns:
+        A tuple of all supported language names.
+    """
+    return _SUPPORTED_LANGUAGES
+
+
+__all__ = ["SupportedLanguage", "get_binding", "get_language", "get_parser", "get_supported_languages"]


### PR DESCRIPTION
The package exports a `SupportedLanguage` Literal type but has no runtime way to enumerate supported languages. I'm currently relying on `SupportedLanguage.__args__` to get the list, and the project's own test suite does the same with a `# type: ignore`.

This adds a `get_supported_languages()` function that returns a tuple of all supported language name strings, and exports it in `__all__`.


edit: Sorry I made a mistake and was  working out of your previous library. I'm glad this feature is now available here and I will update my dependencies