### PR TITLE
feat: add C# language support

### DIFF
--- a/crates/ts-pack-core/Cargo.toml
+++ b/crates/ts-pack-core/Cargo.toml
@@ -47,6 +47,7 @@ all = [
     "lang-commonlisp",
     "lang-cpon",
     "lang-cpp",
+    "lang-csharp",
     "lang-css",
     "lang-csv",
     "lang-cuda",
@@ -343,6 +344,7 @@ lang-comment = []
 lang-commonlisp = []
 lang-cpon = []
 lang-cpp = []
+lang-csharp = []
 lang-css = []
 lang-csv = []
 lang-cuda = []

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -120,6 +120,11 @@
 		"repo": "https://github.com/tree-sitter/tree-sitter-cpp",
 		"rev": "8b5b49eb196bec7040441bee33b2c9a4838d6967"
 	},
+	"csharp": {
+		"repo": "https://github.com/tree-sitter/tree-sitter-c-sharp",
+		"rev": "88366631d598ce6595ec655ce1591b315cffb14c",
+		"branch": "master"
+	},
 	"css": {
 		"branch": "master",
 		"repo": "https://github.com/tree-sitter/tree-sitter-css",

--- a/tools/e2e-generator/fixtures/smoke/csharp.json
+++ b/tools/e2e-generator/fixtures/smoke/csharp.json
@@ -1,0 +1,12 @@
+{
+	"assertions": {
+		"root_child_count_min": 1,
+		"tree_not_null": true
+	},
+	"category": "smoke",
+	"description": "Smoke test: load csharp and parse a simple snippet",
+	"id": "smoke_csharp",
+	"language": "csharp",
+	"source_code": "class Main {}",
+	"tags": ["smoke"]
+}


### PR DESCRIPTION
C# is a top-10 language but isn't available as a parseable language in the pack. the grammar is maintained by the tree-sitter org: https://github.com/tree-sitter/tree-sitter-c-sharp

this was in the 0.x Python package via `tree-sitter-c-sharp` — the 1.0 rewrite just never added it. [issue #60](https://github.com/kreuzberg-dev/tree-sitter-language-pack/issues/60) confirmed it was welcome.

worth noting: the C# *bindings* already exist in `packages/csharp/` (for using the library from C# code). this adds C# as a *parseable language* so you can actually analyze C# source files.

3 files, 19 lines — language definition, cargo feature, and a smoke test. the architecture handles everything else automatically.