### PR TITLE
Reuse parsers and compiled queries in core

### DIFF
--- a/crates/ts-pack-core/src/parse.rs
+++ b/crates/ts-pack-core/src/parse.rs
@@ -1,4 +1,10 @@
 use crate::Error;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static PARSER_CACHE: RefCell<HashMap<String, tree_sitter::Parser>> = RefCell::new(HashMap::new());
+}
 
 /// Parse source code with the named language, returning the syntax tree.
 ///
@@ -11,8 +17,26 @@ use crate::Error;
 /// assert_eq!(tree.root_node().kind(), "module");
 /// ```
 pub fn parse_string(language: &str, source: &[u8]) -> Result<tree_sitter::Tree, Error> {
-    let mut parser = crate::get_parser(language)?;
-    parser.parse(source, None).ok_or(Error::ParseFailed)
+    let language_obj = crate::get_language(language)?;
+    PARSER_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if !cache.contains_key(language) {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&language_obj)
+                .map_err(|e| Error::ParserSetup(format!("{e}")))?;
+            cache.insert(language.to_string(), parser);
+        }
+        let parser = cache
+            .get_mut(language)
+            .ok_or_else(|| Error::ParserSetup("parser cache lookup failed".to_string()))?;
+        parser.parse(source, None).ok_or(Error::ParseFailed)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn cached_parser_count_for_tests() -> usize {
+    PARSER_CACHE.with(|cache| cache.borrow().len())
 }
 
 /// Check whether any node in the tree matches the given type name.
@@ -97,6 +121,22 @@ mod tests {
         let first = &langs[0];
         let tree = parse_string(first, b"x");
         assert!(tree.is_ok(), "parse_string should succeed for '{first}'");
+    }
+
+    #[test]
+    fn test_parse_string_reuses_thread_local_parser_cache() {
+        if skip_if_no_languages() {
+            return;
+        }
+        let langs = crate::available_languages();
+        let first = &langs[0];
+        let before = cached_parser_count_for_tests();
+        let _ = parse_string(first, b"x").unwrap();
+        let after_first = cached_parser_count_for_tests();
+        let _ = parse_string(first, b"y").unwrap();
+        let after_second = cached_parser_count_for_tests();
+        assert!(after_first >= before);
+        assert_eq!(after_second, after_first);
     }
 
     #[test]

--- a/crates/ts-pack-core/src/query.rs
+++ b/crates/ts-pack-core/src/query.rs
@@ -1,8 +1,24 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::sync::{Arc, LazyLock, RwLock};
 
 use crate::Error;
 use crate::node::{NodeInfo, node_info_from_node};
 use tree_sitter::StreamingIterator;
+
+#[derive(Debug)]
+struct CompiledQuery {
+    query: tree_sitter::Query,
+    capture_names: Vec<Cow<'static, str>>,
+}
+
+type QueryCacheMap = ahash::AHashMap<(String, String), Arc<CompiledQuery>>;
+
+static QUERY_CACHE: LazyLock<RwLock<QueryCacheMap>> = LazyLock::new(|| RwLock::new(QueryCacheMap::new()));
+
+thread_local! {
+    static LOCAL_QUERY_CACHE: RefCell<QueryCacheMap> = RefCell::new(QueryCacheMap::new());
+}
 
 /// A single match from a tree-sitter query, with captured nodes.
 #[derive(Debug, Clone)]
@@ -47,16 +63,10 @@ pub fn run_query(
     query_source: &str,
     source: &[u8],
 ) -> Result<Vec<QueryMatch>, Error> {
-    let lang = crate::get_language(language)?;
-    let query = tree_sitter::Query::new(&lang, query_source).map_err(|e| Error::QueryError(format!("{e}")))?;
-    let capture_names: Vec<Cow<'static, str>> = query
-        .capture_names()
-        .iter()
-        .map(|s| Cow::Owned(s.to_string()))
-        .collect();
+    let query = compiled_query(language, query_source)?;
 
     let mut cursor = tree_sitter::QueryCursor::new();
-    let mut matches = cursor.matches(&query, tree.root_node(), source);
+    let mut matches = cursor.matches(&query.query, tree.root_node(), source);
 
     // Tree-sitter 0.26+ evaluates standard text predicates (`#eq?`, `#not-eq?`,
     // `#match?`, `#not-match?`, `#any-of?`, `#not-any-of?`) internally via
@@ -70,7 +80,7 @@ pub fn run_query(
             .captures
             .iter()
             .map(|c| {
-                let name = capture_names[c.index as usize].clone();
+                let name = query.capture_names[c.index as usize].clone();
                 let info = node_info_from_node(c.node);
                 (name, info)
             })
@@ -81,6 +91,36 @@ pub fn run_query(
         });
     }
     Ok(results)
+}
+
+fn compiled_query(language: &str, query_source: &str) -> Result<Arc<CompiledQuery>, Error> {
+    let key = (language.to_string(), query_source.to_string());
+    if let Some(query) = LOCAL_QUERY_CACHE.with(|cache| cache.borrow().get(&key).cloned()) {
+        return Ok(query);
+    }
+    if let Some(query) = QUERY_CACHE.read().ok().and_then(|cache| cache.get(&key).cloned()) {
+        LOCAL_QUERY_CACHE.with(|cache| {
+            cache.borrow_mut().insert(key.clone(), Arc::clone(&query));
+        });
+        return Ok(query);
+    }
+
+    let lang = crate::get_language(language)?;
+    let query = tree_sitter::Query::new(&lang, query_source).map_err(|e| Error::QueryError(format!("{e}")))?;
+    let capture_names = query
+        .capture_names()
+        .iter()
+        .map(|s| Cow::Owned(s.to_string()))
+        .collect();
+    let query = Arc::new(CompiledQuery { query, capture_names });
+    LOCAL_QUERY_CACHE.with(|cache| {
+        cache.borrow_mut().insert(key.clone(), Arc::clone(&query));
+    });
+    if let Ok(mut cache) = QUERY_CACHE.write() {
+        Ok(cache.entry(key).or_insert_with(|| Arc::clone(&query)).clone())
+    } else {
+        Ok(query)
+    }
 }
 
 #[cfg(test)]
@@ -127,5 +167,18 @@ mod tests {
             assert!(matches.is_empty());
         }
         // Query compilation error is fine for some grammars
+    }
+
+    #[test]
+    fn test_compiled_query_reused() {
+        let langs = crate::available_languages();
+        if langs.is_empty() {
+            return;
+        }
+        let first = &langs[0];
+        let query_src = "(identifier) @id";
+        let q1 = compiled_query(first, query_src).unwrap();
+        let q2 = compiled_query(first, query_src).unwrap();
+        assert!(Arc::ptr_eq(&q1, &q2));
     }
 }


### PR DESCRIPTION
## Summary
- reuse a thread-local parser per language in `parse_string()`
- cache compiled tree-sitter queries and capture names for repeated `run_query()` calls
- add focused tests covering parser cache reuse and compiled-query reuse

## Why
These changes target the hot path in `ts-pack-core` without changing the public `run_query()` contract. They avoid repeated parser setup and repeated query compilation/capture-name allocation when the same language/query is used across many files.

## Validation
- `cargo test --manifest-path Cargo.toml -p tree-sitter-language-pack test_parse_string_reuses_thread_local_parser_cache -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p tree-sitter-language-pack test_compiled_query_reused -- --nocapture`
- `cargo check --manifest-path Cargo.toml -p tree-sitter-language-pack`