### PR TITLE
fix: wire auto-download through process() and fix Python error types

### DIFF
--- a/crates/ts-pack-core/src/lib.rs
+++ b/crates/ts-pack-core/src/lib.rs
@@ -238,9 +238,10 @@ pub fn language_count() -> usize {
 /// println!("Structures: {}", result.structure.len());
 /// ```
 pub fn process(source: &str, config: &ProcessConfig) -> Result<ProcessResult, Error> {
-    // Ensure cache is registered before attempting to process
+    // Trigger auto-download for the requested language if not already cached.
+    // get_language() contains the download fallback path; REGISTRY.process() does not.
     #[cfg(feature = "download")]
-    ensure_cache_registered()?;
+    get_language(&config.language)?;
 
     REGISTRY.process(source, config)
 }

--- a/crates/ts-pack-python/src/lib.rs
+++ b/crates/ts-pack-python/src/lib.rs
@@ -315,8 +315,8 @@ impl TreeHandle {
 #[pyfunction]
 fn parse_string(language: &str, source: &str) -> PyResult<TreeHandle> {
     let source_bytes = source.as_bytes();
-    let tree = tree_sitter_language_pack::parse_string(language, source_bytes)
-        .map_err(|e| ParseError::new_err(format!("{e}")))?;
+    let tree = without_gil(|| tree_sitter_language_pack::parse_string(language, source_bytes))
+        .map_err(|e| map_core_error(e))?;
     Ok(TreeHandle {
         inner: Mutex::new(tree),
         source: source_bytes.to_vec(),
@@ -522,10 +522,21 @@ fn json_value_to_py(py: Python<'_>, value: &serde_json::Value) -> PyResult<Py<Py
 #[pyfunction]
 fn process(py: Python<'_>, source: &str, config: &ProcessConfig) -> PyResult<Py<PyAny>> {
     let core_config: tree_sitter_language_pack::ProcessConfig = config.into();
-    let result =
-        tree_sitter_language_pack::process(source, &core_config).map_err(|e| ParseError::new_err(format!("{e}")))?;
+    let result = without_gil(|| tree_sitter_language_pack::process(source, &core_config))
+        .map_err(|e| map_core_error(e))?;
     let value = serde_json::to_value(&result).map_err(|e| ParseError::new_err(format!("serialization failed: {e}")))?;
     json_value_to_py(py, &value)
+}
+
+/// Map a core Error to the most specific Python exception type.
+fn map_core_error(e: tree_sitter_language_pack::Error) -> pyo3::PyErr {
+    match e {
+        tree_sitter_language_pack::Error::LanguageNotFound(_) => LanguageNotFoundError::new_err(format!("{e}")),
+        tree_sitter_language_pack::Error::Download(_) | tree_sitter_language_pack::Error::ChecksumMismatch { .. } => {
+            DownloadError::new_err(format!("{e}"))
+        }
+        _ => ParseError::new_err(format!("{e}")),
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
   
  ## problem                                                                                
                                                                                            
  `process()` called `REGISTRY.process()` directly, which internally uses `LanguageRegistry::get_language()` — a method with no download logic. The module-level `get_language()` is the only path that triggers auto-download, and `process()` bypassed it entirely.
                                                                                            
  `ParseError: Language 'X' not found` instead of downloading, despite the docs stating "parsers download automatically on first use."                           
                                                                                            
  ## fix                                                                                  
                                                                                            
  - **`crates/ts-pack-core/src/lib.rs`** — `process()` now calls                          
    `get_language()` before delegating to the registry, ensuring the                        
    download path is exercised.                                                           
  - **`crates/ts-pack-python/src/lib.rs`** — `process()` and                                
    `parse_string()` were mapping all core errors to `ParseError`.
    Added `map_core_error()` to route `LanguageNotFound` →                                  
    `LanguageNotFoundError` and download failures → `DownloadError`.                        
    Both functions now also release the GIL during blocking I/O.    
                                                                                            
  ## testing                                                                              
                                                                                            
  - Verified exact reproducer from #90 works on a clean install                           
  - Confirmed correct exception types for unknown language and network failure              
  - 99/100 core Rust unit tests pass (1 pre-existing unrelated failure)
  - 25/25 Python e2e tests pass                                                             
                                                                                          
  fixes #90         