### PR TITLE
 fix(deps): bump rustls-webpki to patch RUSTSEC-2026-0098 and RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
  `rustls-webpki v0.103.10` has two newly published CVEs that are causing `cargo-deny` to fail on all PRs and pushes to main.
                                                                                           
  - RUSTSEC-2026-0098 - URI name constraints incorrectly accepted
  - RUSTSEC-2026-0099 - Wildcard name accepted under DNS name constraint
                                                                                           
  `cargo update -p rustls-webpki` bumps to v0.103.12 which patches both.
                                                                                           
  closes #98    