### PR TITLE
docs: regenerate READMEs for 1.6.1 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ See [Go README](packages/go/README.md) for full documentation.
 <dependency>
   <groupId>dev.kreuzberg</groupId>
   <artifactId>tree-sitter-language-pack</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
 </dependency>
 ```
 
 ```groovy
-implementation("dev.kreuzberg:tree-sitter-language-pack:1.6.0")
+implementation("dev.kreuzberg:tree-sitter-language-pack:1.6.1")
 ```
 
 See [Java README](crates/ts-pack-java/README.md) for full documentation.

--- a/crates/ts-pack-java/README.md
+++ b/crates/ts-pack-java/README.md
@@ -61,12 +61,12 @@ Java bindings for tree-sitter-language-pack with on-demand parser downloads (JDK
 <dependency>
   <groupId>dev.kreuzberg</groupId>
   <artifactId>tree-sitter-language-pack</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
 </dependency>
 ```
 
 ```groovy
-implementation("dev.kreuzberg:tree-sitter-language-pack:1.6.0")
+implementation("dev.kreuzberg:tree-sitter-language-pack:1.6.1")
 ```
 
 ## Quick Start


### PR DESCRIPTION
The 1.6.1 release commit (635fda7) bumped the version but the Maven/Gradle snippets in `README.md` and `crates/ts-pack-java/README.md` still say 1.6.0, so the "README validation" CI check has been failing on `main`.

This is just the output of `python scripts/generate_readme.py`.