### PR TITLE
Fix Go language-pack bindings and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,8 +127,27 @@ repos:
     hooks:
       - id: textlint
         name: textlint (docs prose)
-        entry: npx textlint
+        entry: textlint
         language: node
+        additional_dependencies:
+          - textlint@15.5.4
+          - textlint-filter-rule-comments@1.3.0
+          - textlint-filter-rule-node-types@1.1.0
+          - textlint-rule-alex@5.0.0
+          - textlint-rule-common-misspellings@1.0.1
+          - textlint-rule-doubled-spaces@1.0.2
+          - textlint-rule-en-capitalization@2.0.3
+          - textlint-rule-en-max-word-count@2.0.1
+          - textlint-rule-no-empty-section@1.1.0
+          - textlint-rule-no-start-duplicated-conjunction@2.0.2
+          - textlint-rule-no-surrogate-pair@1.0.1
+          - textlint-rule-no-todo@2.0.1
+          - textlint-rule-no-zero-width-spaces@1.0.1
+          - textlint-rule-stop-words@5.2.0
+          - textlint-rule-terminology@5.2.16
+          - textlint-rule-write-good@2.0.0
+          - '@textlint-rule/textlint-rule-no-invalid-control-character@3.0.0'
+          - '@textlint-rule/textlint-rule-no-unmatched-pair@2.0.4'
         files: ^docs/.*\.md$
         exclude: ^docs/(CHANGELOG|snippets/)
         pass_filenames: true

--- a/.task/go.yml
+++ b/.task/go.yml
@@ -5,6 +5,8 @@ tasks:
     desc: Build FFI static library for Go
     env:
       PROJECT_ROOT: "{{.PROJECT_ROOT}}"
+      TSLP_LINK_MODE: '{{default "static" .TSLP_LINK_MODE}}'
+      TSLP_LANGUAGES: '{{default "python,rust,javascript,typescript,go,html,css,json" .TSLP_LANGUAGES}}'
     cmds:
       - cargo build -p ts-pack-ffi --release
 

--- a/crates/ts-pack-ffi/src/lib.rs
+++ b/crates/ts-pack-ffi/src/lib.rs
@@ -97,6 +97,10 @@ pub unsafe extern "C" fn ts_pack_registry_new() -> *mut TsPackRegistry {
     ffi_guard!(ptr::null_mut(), {
         clear_last_error();
         let inner = LanguageRegistry::new();
+        #[cfg(feature = "download")]
+        if let Ok(cache_dir) = tree_sitter_language_pack::cache_dir() {
+            inner.add_extra_libs_dir(cache_dir);
+        }
         let names: Vec<CString> = inner
             .available_languages()
             .into_iter()

--- a/crates/ts-pack-ffi/src/lib.rs
+++ b/crates/ts-pack-ffi/src/lib.rs
@@ -97,7 +97,6 @@ pub unsafe extern "C" fn ts_pack_registry_new() -> *mut TsPackRegistry {
     ffi_guard!(ptr::null_mut(), {
         clear_last_error();
         let inner = LanguageRegistry::new();
-        #[cfg(feature = "download")]
         if let Ok(cache_dir) = tree_sitter_language_pack::cache_dir() {
             inner.add_extra_libs_dir(cache_dir);
         }

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -72,22 +72,22 @@ import (
 )
 
 func main() {
+    if err := tspack.Init(`{"languages":["go"]}`); err != nil {
+        panic(err)
+    }
+
     reg, _ := tspack.NewRegistry()
     defer reg.Close()
-
-    // Optional: Pre-download specific languages for offline use
-    reg.Init([]string{"python", "go", "rust"})
 
     langs := reg.AvailableLanguages()
     fmt.Println(langs)
 
-    // Auto-downloads language if not cached
     config := tspack.ProcessConfig{Language: "go"}
-    result, _ := reg.Process(source, config)
+    result, _ := reg.Process("package main\nfunc main() {}\n", config)
     fmt.Printf("Functions: %d\n", len(result.Structure))
 
-    // Pre-download languages for offline use
-    reg.Download([]string{"python", "javascript"})
+    downloaded, _ := tspack.Download([]string{"python", "javascript"})
+    fmt.Printf("Downloaded: %d\n", downloaded)
 }
 ```
 
@@ -113,8 +113,8 @@ func main() {
 
 ### Download API
 
-- `Registry.Init(languages)` -- pre-download specific languages for offline use
-- `Registry.Download(languages)` -- download parsers on demand
+- `Init(configJSON)` -- configure the cache and optionally pre-download languages
+- `Download(languages)` -- download parsers on demand
 
 ### Intelligence
 

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -68,25 +68,35 @@ package main
 
 import (
     "fmt"
+    "log"
     tspack "github.com/kreuzberg-dev/tree-sitter-language-pack/packages/go"
 )
 
 func main() {
     if err := tspack.Init(`{"languages":["go"]}`); err != nil {
-        panic(err)
+        log.Fatal(err)
     }
 
-    reg, _ := tspack.NewRegistry()
+    reg, err := tspack.NewRegistry()
+    if err != nil {
+        log.Fatal(err)
+    }
     defer reg.Close()
 
     langs := reg.AvailableLanguages()
     fmt.Println(langs)
 
     config := tspack.ProcessConfig{Language: "go"}
-    result, _ := reg.Process("package main\nfunc main() {}\n", config)
+    result, err := reg.Process("package main\nfunc main() {}\n", config)
+    if err != nil {
+        log.Fatal(err)
+    }
     fmt.Printf("Functions: %d\n", len(result.Structure))
 
-    downloaded, _ := tspack.Download([]string{"python", "javascript"})
+    downloaded, err := tspack.Download([]string{"python", "javascript"})
+    if err != nil {
+        log.Fatal(err)
+    }
     fmt.Printf("Downloaded: %d\n", downloaded)
 }
 ```

--- a/packages/go/ffi.go
+++ b/packages/go/ffi.go
@@ -9,16 +9,5 @@ package tspack
 #include "ts_pack.h"
 #include <stdlib.h>
 #include <stdint.h>
-
-// Forward declarations for download/configure API
-int32_t ts_pack_init(const char *config_json);
-int32_t ts_pack_configure(const char *config_json);
-int32_t ts_pack_download(const char *const *names, uintptr_t count);
-int32_t ts_pack_download_all(void);
-const char *const *ts_pack_manifest_languages(uintptr_t *out_count);
-const char *const *ts_pack_downloaded_languages(uintptr_t *out_count);
-int32_t ts_pack_clean_cache(void);
-const char *ts_pack_cache_dir(void);
-void ts_pack_free_string_array(const char **arr);
 */
 import "C"

--- a/packages/go/ffi_dev.go
+++ b/packages/go/ffi_dev.go
@@ -4,9 +4,9 @@ package tspack
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../crates/ts-pack-ffi/include
-#cgo darwin LDFLAGS: ${SRCDIR}/../../crates/ts-pack-ffi/target/release/libts_pack_ffi.a -lc++
-#cgo linux LDFLAGS: -L${SRCDIR}/../../crates/ts-pack-ffi/target/release -Wl,-Bstatic -lts_pack_ffi -Wl,-Bdynamic -lpthread -ldl -lm -lstdc++
-#cgo windows LDFLAGS: -L${SRCDIR}/../../crates/ts-pack-ffi/target/release -lts_pack_ffi -lws2_32 -lbcrypt -lntdll -static-libgcc -static-libstdc++
+#cgo darwin LDFLAGS: ${SRCDIR}/../../target/release/libts_pack_ffi.a -lc++
+#cgo linux LDFLAGS: -L${SRCDIR}/../../target/release -Wl,-Bstatic -lts_pack_ffi -Wl,-Bdynamic -lpthread -ldl -lm -lstdc++
+#cgo windows LDFLAGS: -L${SRCDIR}/../../target/release -lts_pack_ffi -lws2_32 -lbcrypt -lntdll -static-libgcc -static-libstdc++
 #include "ts_pack.h"
 #include <stdlib.h>
 #include <stdint.h>

--- a/scripts/readme_config.yaml
+++ b/scripts/readme_config.yaml
@@ -191,22 +191,22 @@ languages:
       )
 
       func main() {
+          if err := tspack.Init(`{"languages":["go"]}`); err != nil {
+              panic(err)
+          }
+
           reg, _ := tspack.NewRegistry()
           defer reg.Close()
-
-          // Optional: Pre-download specific languages for offline use
-          reg.Init([]string{"python", "go", "rust"})
 
           langs := reg.AvailableLanguages()
           fmt.Println(langs)
 
-          // Auto-downloads language if not cached
           config := tspack.ProcessConfig{Language: "go"}
-          result, _ := reg.Process(source, config)
+          result, _ := reg.Process("package main\nfunc main() {}\n", config)
           fmt.Printf("Functions: %d\n", len(result.Structure))
 
-          // Pre-download languages for offline use
-          reg.Download([]string{"python", "javascript"})
+          downloaded, _ := tspack.Download([]string{"python", "javascript"})
+          fmt.Printf("Downloaded: %d\n", downloaded)
       }
 
   java:

--- a/scripts/readme_config.yaml
+++ b/scripts/readme_config.yaml
@@ -187,25 +187,35 @@ languages:
 
       import (
           "fmt"
+          "log"
           tspack "github.com/kreuzberg-dev/tree-sitter-language-pack/packages/go"
       )
 
       func main() {
           if err := tspack.Init(`{"languages":["go"]}`); err != nil {
-              panic(err)
+              log.Fatal(err)
           }
 
-          reg, _ := tspack.NewRegistry()
+          reg, err := tspack.NewRegistry()
+          if err != nil {
+              log.Fatal(err)
+          }
           defer reg.Close()
 
           langs := reg.AvailableLanguages()
           fmt.Println(langs)
 
           config := tspack.ProcessConfig{Language: "go"}
-          result, _ := reg.Process("package main\nfunc main() {}\n", config)
+          result, err := reg.Process("package main\nfunc main() {}\n", config)
+          if err != nil {
+              log.Fatal(err)
+          }
           fmt.Printf("Functions: %d\n", len(result.Structure))
 
-          downloaded, _ := tspack.Download([]string{"python", "javascript"})
+          downloaded, err := tspack.Download([]string{"python", "javascript"})
+          if err != nil {
+              log.Fatal(err)
+          }
           fmt.Printf("Downloaded: %d\n", downloaded)
       }
 

--- a/scripts/readme_templates/language_package.md.jinja
+++ b/scripts/readme_templates/language_package.md.jinja
@@ -144,8 +144,8 @@ TSLP_LANGUAGES=python,rust,javascript cargo build
 
 ### Download API
 
-- `Registry.Init(languages)` -- pre-download specific languages for offline use
-- `Registry.Download(languages)` -- download parsers on demand
+- `Init(configJSON)` -- configure the cache and optionally pre-download languages
+- `Download(languages)` -- download parsers on demand
 
 ### Intelligence
 


### PR DESCRIPTION
## Summary
- fix the Go dev-mode linker path for workspace builds
- stop redeclaring FFI symbols in `packages/go/ffi.go` so the header stays authoritative
- register the download cache when the FFI creates a registry
- correct the generated Go quick-start and download API docs

## Verification
- `go test -tags=tspack_dev ./...` in `tests/test_apps/go`
- `go test ./...` in `tests/test_apps/go` after vendoring FFI artifacts with `python3 scripts/ci/go/vendor-ffi.py`

## Notes
I also reproduced the published-module failure mode locally before making these changes. The current published Go module still depends on release packaging to vendor the FFI artifacts, but the binding code and generated docs are now aligned with the actual working paths in the repo.