### PR TITLE
docs: revert the double header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,6 @@ title: tree-sitter-language-pack
 description: "tree-sitter-language-pack — 306 tree-sitter parsers with bindings for Python, TypeScript, Rust, Go, Java, Ruby, Elixir, PHP, and WebAssembly."
 ---
 
-## tree-sitter-language-pack
-
 tree-sitter-language-pack bundles 306 [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammars behind a single Rust core with native bindings for Python, TypeScript, Rust, Go, Java, Ruby, Elixir, PHP, WebAssembly, and more. Parsers download on demand and cache locally. One API surface for parsing, code intelligence, extraction queries, and syntax-aware chunking for LLM workflows. It ships as libraries per ecosystem plus the `ts-pack` CLI.
 
 <div class="hero-badges" markdown>
@@ -16,7 +14,7 @@ tree-sitter-language-pack bundles 306 [tree-sitter](https://tree-sitter.github.i
 
 ---
 
-### Explore the Docs
+## Explore the Docs
 
 <div class="grid cards doc-explore-grid" markdown>
 
@@ -65,8 +63,6 @@ tree-sitter-language-pack bundles 306 [tree-sitter](https://tree-sitter.github.i
     ---
 
     Full reference for Python, TypeScript, Rust, Go, Java, Ruby, Elixir, PHP, WASM, C FFI, and the CLI.
-
-    [:material-arrow-right: Python API](api/python.md)
 
 </div>
 


### PR DESCRIPTION
## Related

<!-- Link issues or discussions if applicable -->

## Description

This pull request makes minor improvements to the `docs/index.md` documentation for `tree-sitter-language-pack`, focusing on section headings and layout cleanup.

Documentation improvements:

* Removed a redundant top-level heading and adjusted section headings for better structure and clarity. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L6-L7) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L19-R17)
* Cleaned up the API reference section by removing an unnecessary link, improving the layout of the documentation.
## Checklist

- [ ] CI passing
- [ ] Tests added where applicable
