### PR TITLE
chore(al): bump tree-sitter-al to v2.5.1

### DIFF
--- a/crates/ts-pack-core/language_definitions.json
+++ b/crates/ts-pack-core/language_definitions.json
@@ -24,7 +24,7 @@
   "al": {
     "extensions": ["al"],
     "repo": "https://github.com/SShadowS/tree-sitter-al",
-    "rev": "3e4ccb672f27d1ad673a8a995b1f5c770bb0f738"
+    "rev": "0d5b5cf95b2c239a57907c5b240c2b1303e7096d"
   },
   "angular": {
     "extensions": [],

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -24,7 +24,7 @@
   "al": {
     "extensions": ["al"],
     "repo": "https://github.com/SShadowS/tree-sitter-al",
-    "rev": "3e4ccb672f27d1ad673a8a995b1f5c770bb0f738"
+    "rev": "0d5b5cf95b2c239a57907c5b240c2b1303e7096d"
   },
   "angular": {
     "extensions": [],


### PR DESCRIPTION
Bumps the pinned `tree-sitter-al` revision from v2.5.0 (`3e4ccb6`) to
v2.5.1 (`0d5b5cf`).

v2.5.1 is an internal optimization release: parser state count −40.8%
and `parser.c` size −38.7% versus the prior tagged state, achieved by
factoring shared grammar structure into hidden rules. **Zero behavior
change** — every one of the 15,358 production AL test files parses to a
byte-identical syntax tree (verified with a parse-tree diff harness).
1,437 corpus tests pass, 0 errors.

Release: https://github.com/SShadowS/tree-sitter-al/releases/tag/v2.5.1