### PR TITLE
fix(download): honor proxy env vars when fetching grammars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +2926,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ toml = "1.1"
 toml_edit = "0.25"
 tree-sitter = "0.26"
 tree-sitter-language-pack = { path = "crates/ts-pack-core" }
-ureq = { version = "3", features = ["platform-verifier"] }
+ureq = { version = "3", features = ["platform-verifier", "socks-proxy"] }
 walkdir = "2.5"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"

--- a/crates/ts-pack-core/src/download.rs
+++ b/crates/ts-pack-core/src/download.rs
@@ -207,6 +207,13 @@ fn build_agent(mode: TlsRootsMode) -> ureq::Agent {
     ureq::Agent::config_builder()
         .tls_config(ureq::tls::TlsConfig::builder().root_certs(root_certs).build())
         .timeout_global(Some(HTTP_TIMEOUT))
+        // Honor standard proxy environment variables (HTTPS_PROXY / HTTP_PROXY /
+        // ALL_PROXY, incl. socks5://). Without this the agent always connects
+        // directly, so on networks where the GitHub release host is only
+        // reachable through a proxy the grammar download stalls until the
+        // global timeout fires (and pre-timeout builds hung forever). Proxy is
+        // applied only when the env vars are set; otherwise this is a no-op.
+        .proxy(ureq::Proxy::try_from_env())
         .build()
         .new_agent()
 }


### PR DESCRIPTION
> Supersedes #138 (that PR was auto-closed by GitHub after an accidental
> force-push from a shallow clone left its head with no merge base; it can no
> longer be reopened). This PR contains the identical change on a clean
> single commit based on `main`.

## Problem

`build_agent` (`crates/ts-pack-core/src/download.rs`) constructs the `ureq`
agent with TLS roots and a global timeout, but never configures a proxy. As a
result, manifest/grammar downloads from the GitHub release host always connect
**directly**, ignoring `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY`.

On networks where the release host is only reachable through a proxy
(corporate proxies, or regions where GitHub is blocked), the download stalls.
On builds without the global timeout (e.g. 1.6.2) this manifests as
`get_language()` **hanging forever** in `__recvfrom` with no way to recover —
which takes down downstream consumers such as Semble's code indexing.

This is the root cause behind the macOS report in #137 and the closed
downstream issue MinishLab/semble#151: the symptom looked like a native
deadlock, but it's an unproxied HTTP read that never returns.

## Fix

- Enable ureq's `socks-proxy` feature (so `socks5://` proxies work).
- `build_agent`: add `.proxy(ureq::Proxy::try_from_env())`.

`try_from_env()` returns `None` when no proxy env vars are set, so this is a
**no-op for existing users** and only changes behavior when a proxy is
explicitly configured in the environment.

## Verification (macOS arm64, toolchain 1.95)

- `cargo check -p tree-sitter-language-pack --features download` passes;
  `cargo clippy … -- -D warnings` is clean on the change.
- A standalone `ureq` agent built the same way (TLS + global timeout +
  `.proxy(try_from_env())`, `socks-proxy` feature on):
  - **with** `ALL_PROXY=socks5://…` → downloads `v1.6.2/parsers.json`
    successfully (**HTTP 200, 24760 bytes**);
  - **without** any proxy env → fails with `timeout: global` (the same code
    path that, pre-timeout, hung forever).

Refs #137, MinishLab/semble#151
