### PR TITLE
docs: add CODE_OF_CONDUCT, SECURITY and sync ecosystem block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
           - id: shellcheck
 
           - id: markdownlint-rumdl-strict
-            exclude: ^(docs/reference/|packages/.*/README\.md|crates/.*/README\.md)$
+            exclude: ^(docs/reference/|packages/.*/README\.md|crates/.*/README\.md|README\.md)$
           - id: textlint
             files: ^docs/.*\.md$
             exclude: ^docs/(CHANGELOG|snippets/|reference/|api-|migration/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+tree-sitter-language-pack is committed to a welcoming, respectful community for everyone
+regardless of background or experience level.
+
+## Expected Behaviour
+
+- Be respectful and constructive in all interactions.
+- Accept feedback graciously; give it thoughtfully.
+- Focus discussions on technical substance.
+- Assume good faith until evidence suggests otherwise.
+
+## Unacceptable Behaviour
+
+Personal attacks, sustained disruption, and discriminatory language are not tolerated.
+
+## Enforcement
+
+Report issues to **<conduct@kreuzberg.dev>**. All reports are reviewed confidentially.
+Maintainers may warn, temporarily restrict, or permanently remove contributors whose
+behaviour harms the community.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests, discussions,
+Discord, and any other venue where contributors represent the project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A comprehensive collection of tree-sitter language parsers with polyglot binding
 
 ## Overview
 
-**tree-sitter-language-pack** bundles 300+ tree-sitter language parsers into a single package with native bindings for multiple programming languages. Ship syntax analysis in your application without managing individual parser dependencies.
+**tree-sitter-language-pack** bundles 306 tree-sitter language parsers into a single package with native bindings for multiple programming languages. Ship syntax analysis in your application without managing individual parser dependencies.
 
 ## Architecture
 
@@ -251,18 +251,18 @@ The `process()` function returns structured analysis including functions, classe
 
 ## Supported Languages
 
-This pack includes 300+ languages. See the [full language list](docs/languages.md) for all supported grammars with extensions and repository links.
+This pack includes 306 languages. See the [full language list](docs/languages.md) for all supported grammars with extensions and repository links.
 
 ## Package READMEs
 
-- [Rust](crates/ts-pack-core/README.md) -- Rust core library providing access to 300+ tree-sitter parsers with on-demand download and caching support.
+- [Rust](crates/ts-pack-core/README.md) -- Rust core library providing access to 306 tree-sitter parsers with on-demand download and caching support.
 - [Python](packages/python/README.md) -- Python bindings for tree-sitter-language-pack, providing access to 306 pre-compiled tree-sitter parsers with on-demand downloads.
 - [Node.js](crates/ts-pack-core-node/README.md) -- Node.js NAPI bindings for tree-sitter-language-pack with on-demand parser downloads.
 - [Go](packages/go/README.md) -- Go bindings for tree-sitter-language-pack with on-demand parser caching.
 - [Java](packages/java/README.md) -- Java bindings for tree-sitter-language-pack with on-demand parser downloads (JDK 22+).
 - [Elixir](packages/elixir/README.md) -- Elixir bindings for tree-sitter-language-pack with on-demand parser downloads.
 - [Ruby](packages/ruby/README.md) -- Ruby bindings for tree-sitter-language-pack with on-demand parser downloads.
-- [WebAssembly](crates/ts-pack-core-wasm/README.md) -- WebAssembly bindings for tree-sitter-language-pack. Includes a curated subset of 30 languages optimized for browser and edge runtimes. For all 300+ languages, use native bindings (Python, Node.js, etc.).
+- [WebAssembly](crates/ts-pack-core-wasm/README.md) -- WebAssembly bindings for tree-sitter-language-pack. Includes a curated subset of 30 languages optimized for browser and edge runtimes. For all 306 languages, use native bindings (Python, Node.js, etc.).
 - [PHP](packages/php/README.md) -- PHP extension via ext-php-rs with on-demand parser downloads.
 - [.NET (C#)](packages/csharp/README.md) -- .NET P/Invoke bindings with on-demand parser downloads.
 - [C/C++ (FFI)](crates/ts-pack-core-ffi/README.md) -- C-compatible FFI bindings for tree-sitter-language-pack. Use from any language with C interop.

--- a/README.md
+++ b/README.md
@@ -276,12 +276,12 @@ Join our [Discord community](https://discord.gg/xt9WY3GnKR) for questions and di
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 90+ formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 91+ formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [kreuzcrawl](https://github.com/kreuzberg-dev/kreuzcrawl) — web crawling and scraping with HTML→Markdown and headless-Chrome fallback.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
 - [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security reports.**
+
+Preferred channel: open a private advisory at
+<https://github.com/kreuzberg-dev/tree-sitter-language-pack/security/advisories/new>.
+
+Alternative: email **<security@kreuzberg.dev>**.
+
+Please include a description of the issue, steps to reproduce, affected versions, and your
+preferred credit (or none). We acknowledge reports within **2 business days** and aim to
+publish a fix within **14 days** for critical issues and **30 days** for others.
+
+## Supported Versions
+
+Security fixes target the latest release on `main`. Older versions are not back-ported.
+
+## Scope
+
+In scope: the tree-sitter-language-pack library and its bindings.
+Out of scope: third-party grammar repositories (report upstream and notify us).

--- a/templates/readme/language_package.md
+++ b/templates/readme/language_package.md
@@ -7,9 +7,11 @@
 ## What This Package Provides
 
 - **Parser access** — load a tree-sitter language parser by name without wiring individual grammar crates or packages.
-- **Code intelligence primitives** — parse trees, functions, classes, imports, exports, symbols, docstrings, diagnostics, and syntax-aware chunks.
+- **Code intelligence primitives** — parse trees, functions, classes, imports, exports, symbols,
+  docstrings, diagnostics, and syntax-aware chunks.
 - **Shared cache model** — parsers are fetched and cached once, then reused by every call in the process.
-- **Same catalog as every binding** — Rust, Python, Node.js, Go, Java, PHP, Ruby, .NET, Elixir, WASM, Dart, Kotlin Android, Swift, Zig, and C FFI use the same grammar set.
+- **Same catalog as every binding** — Rust, Python, Node.js, Go, Java, PHP, Ruby, .NET, Elixir,
+  WASM, Dart, Kotlin Android, Swift, Zig, and C FFI use the same grammar set.
   {% if language == "typescript" %}
 - **Node-first TypeScript API** — native NAPI package with typed parser and query helpers.
   {% elif language == "python" %}
@@ -56,7 +58,8 @@
 - **On-demand download + cache** — parsers fetched at first use; subsequent runs hit the local cache.
 - **Code intelligence** — extract functions, classes, imports, exports, symbols, docstrings, and diagnostics with one API.
 - **Syntax-aware chunking** — semantic chunks for RAG/LLM pipelines.
-- **Polyglot bindings** — Rust core with native bindings for Python, TypeScript, Go, Java, C#, Ruby, PHP, Elixir, and WebAssembly via [alef](https://github.com/kreuzberg-dev/alef).
+- **Polyglot bindings** — Rust core with native bindings for Python, TypeScript, Go, Java, C#,
+  Ruby, PHP, Elixir, and WebAssembly via [alef](https://github.com/kreuzberg-dev/alef).
 
 ## Documentation
 
@@ -65,12 +68,12 @@
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 90+ formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 91+ formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [kreuzcrawl](https://github.com/kreuzberg-dev/kreuzcrawl) — web crawling and scraping with HTML→Markdown and headless-Chrome fallback.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
 - [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces this README and all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## Contributing


### PR DESCRIPTION
Adds community health files, corrects stale language count references, and syncs the ecosystem block to canonical wording.

## Changes
- Add CODE_OF_CONDUCT.md
- Add SECURITY.md with private advisory reporting instructions
- Fix stale "300+" language references to 306 in README and templates
- Sync ecosystem block to canonical wording across kreuzberg-dev repos