### PR TITLE
docs: position when tree-sitter-language-pack is the right tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ A comprehensive collection of tree-sitter language parsers with polyglot binding
 
 **tree-sitter-language-pack** bundles 306 tree-sitter language parsers into a single package with native bindings across 15 languages. Ship syntax analysis in your application without managing individual parser dependencies.
 
+> Do you need to parse code? → use **tree-sitter**.
+> Across *lots* of languages? → use a **language pack**.
+> And from a *non-C ecosystem* with one dependency? → that's the narrow slot where **this** pack specifically "makes it easy."
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
## What

Adds a short, three-step blurb to the top of the README (right under the Overview paragraph) clarifying *when* this pack is the right tool:

> Do you need to parse code? → use **tree-sitter**.
> Across *lots* of languages? → use a **language pack**.
> And from a *non-C ecosystem* with one dependency? → that's the narrow slot where **this** pack specifically "makes it easy."

## Why

The README leads with use cases that are really reasons to use **tree-sitter** (the upstream library), not this pack specifically. This blurb honestly separates the three value props — tree-sitter is useful, packs are convenient, and *this* pack's distinctive value is the polyglot binding fan-out for non-C ecosystems — so readers can self-select quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)