### PR TITLE
fix(ci): unblock Clone vendors (revert lean rev, swap, generate timeout)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,19 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
+            # A few monster grammars (lean, zsh, systemverilog) peak above the
+            # 16 GB runner RAM during `tree-sitter generate`. Add swap on the large
+            # /mnt volume so they spill to disk instead of OOM-killing the job
+            # (exit 143). Slower, but the run completes and warms the parser cache.
+            - name: Add swap space
+              run: |
+                  sudo swapoff -a || true
+                  sudo fallocate -l 12G /mnt/swapfile
+                  sudo chmod 600 /mnt/swapfile
+                  sudo mkswap /mnt/swapfile
+                  sudo swapon /mnt/swapfile
+                  free -h
+
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:

--- a/crates/ts-pack-core/language_definitions.json
+++ b/crates/ts-pack-core/language_definitions.json
@@ -956,7 +956,7 @@
 		"extensions": ["lean"],
 		"generate": true,
 		"repo": "https://github.com/Julian/tree-sitter-lean",
-		"rev": "dc5997b2744595eeb389e1ed9c4f5e727c5b655e"
+		"rev": "463a9d8a509c935f4e10854b5078bbe2839b274c"
 	},
 	"ledger": {
 		"abi_version": 14,

--- a/scripts/clone_vendors.py
+++ b/scripts/clone_vendors.py
@@ -45,6 +45,12 @@ parsers_directory = Path(os.environ.get("TSLP_CACHE_DIR", _project_root / "parse
 # cheap and stay wide. Both are env-tunable for constrained environments.
 CLONE_CONCURRENCY = int(os.environ.get("TSLP_CLONE_CONCURRENCY", "16"))
 GENERATE_CONCURRENCY = int(os.environ.get("TSLP_GENERATE_CONCURRENCY", "3"))
+# Per-grammar `tree-sitter generate` timeout (seconds). A few grammars can hang
+# or thrash for many minutes on a bad revision, silently stalling the whole run
+# until the CI runner reaps it (exit 143). On timeout we abandon generation and
+# fall back to the grammar's committed src/parser.c (moved by move_src_folder).
+# 0 disables the timeout. Default 8 min covers the slowest healthy grammars.
+GENERATE_TIMEOUT = int(os.environ.get("TSLP_GENERATE_TIMEOUT", "480"))
 
 CACHE_MANIFEST_FILE = parsers_directory / ".cache_manifest.json"
 
@@ -300,8 +306,20 @@ async def handle_generate(
             cmd = ["tree-sitter", "generate", "--abi", str(abi_version)]
 
         try:
-            await run_process(cmd, cwd=str(target_dir), check=False)
+            run = run_process(cmd, cwd=str(target_dir), check=False)
+            if GENERATE_TIMEOUT > 0:
+                await asyncio.wait_for(run, timeout=GENERATE_TIMEOUT)
+            else:
+                await run
             print(f"Generated {language_name} parser successfully")
+        except (TimeoutError, asyncio.TimeoutError):
+            # Abandon a hung/thrashing generate and fall back to the committed
+            # src/parser.c so one bad grammar can't stall the whole CI run.
+            print(
+                f"WARNING: tree-sitter generate for {language_name} timed out after "
+                f"{GENERATE_TIMEOUT}s; falling back to committed parser.c",
+                flush=True,
+            )
         except Exception as e:
             raise RuntimeError(f"failed to clone {language_name} due to an exception: {e}") from e
 

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -956,7 +956,7 @@
 		"extensions": ["lean"],
 		"generate": true,
 		"repo": "https://github.com/Julian/tree-sitter-lean",
-		"rev": "dc5997b2744595eeb389e1ed9c4f5e727c5b655e"
+		"rev": "463a9d8a509c935f4e10854b5078bbe2839b274c"
 	},
 	"ledger": {
 		"abi_version": 14,


### PR DESCRIPTION
`Clone vendors` has been red for 2+ days, blocking all downstream CI jobs. On a cold cache it regenerates all 143 `generate:true` grammars; a few monster grammars exhaust the 16 GB runner during `tree-sitter generate` and SIGTERM the job (exit 143) before the parser cache can warm — and the cache only saves on success, so it never recovers.

Three changes so one cold run can complete and warm the cache:
- **Revert `lean` to rev `463a9d8a`** — the recent dependency upgrade bumped it to `dc5997b2`, whose `generate` hangs >10 min on CI and was the exact failure point under serialized generation (`TSLP_GENERATE_CONCURRENCY=1`).
- **Add 12 GB swap on `/mnt`** so monster grammars (lean, zsh, systemverilog) spill to disk instead of OOM-killing the job.
- **Per-grammar generate timeout** (`TSLP_GENERATE_TIMEOUT`, default 480s) — on timeout, fall back to the committed `src/parser.c` so one bad grammar can't silently stall the whole run.

Tested on this branch; once `Clone vendors` goes green here the parser cache warms and merges to `main` stay fast.