### PR TITLE
test(e2e/java): regression for kind() and toSexp() raw-string returns

### DIFF
--- a/e2e/java/src/test/java/io/xberg/treesitterlanguagepack/e2e/TreeTraversalTest.java
+++ b/e2e/java/src/test/java/io/xberg/treesitterlanguagepack/e2e/TreeTraversalTest.java
@@ -5,6 +5,11 @@
 // accessors freed the returned native handle immediately after wrapping it, so
 // every returned Tree/Node/TreeCursor wrapped an already-freed pointer and the
 // next native call crashed the JVM with EXCEPTION_ACCESS_VIOLATION.
+//
+// Also covers kind() and toSexp() string-return correctness: alef <= 0.24.x
+// serialized these through serde_json::to_string, producing a JSON-quoted
+// string ("\"module\"" instead of "module"). The JNI shim now passes the raw
+// &str / String directly, so these tests would fail with the old code.
 
 package io.xberg.treesitterlanguagepack.e2e;
 
@@ -61,6 +66,44 @@ public class TreeTraversalTest {
                         "parent of the assignment must be the module");
                 }
             }
+        }
+    }
+
+    @Test
+    void testToSexpReturnsPlainSexpNotJson() throws Exception {
+        // Regression: alef <= 0.24.x routed toSexp() through serde_json::to_string,
+        // so the return value was a JSON-quoted string: "\"(module ...)\"" instead of
+        // "(module ...)". Verify the raw S-expression is returned.
+        Parser parser = TreeSitterLanguagePack.getParser("python");
+
+        try (Tree tree = parser.parse("x = 1").orElseThrow();
+             Node root = tree.rootNode()) {
+            String sexp = root.toSexp();
+            assertNotNull(sexp, "toSexp() must not return null");
+            assertTrue(sexp.startsWith("("),
+                "S-expression must start with '(' — got: " + sexp);
+            assertFalse(sexp.startsWith("\""),
+                "toSexp() must not be JSON-quoted — got: " + sexp);
+            assertTrue(sexp.contains("module"),
+                "Python root sexp must contain 'module' — got: " + sexp);
+        }
+    }
+
+    @Test
+    void testKindReturnsPlainStringNotJson() throws Exception {
+        // Regression: alef <= 0.24.x routed kind() through serde_json::to_string,
+        // returning "\"module\"" instead of "module". This test would pass only with
+        // the raw-string JNI path introduced in alef 0.25.47+.
+        Parser parser = TreeSitterLanguagePack.getParser("python");
+
+        try (Tree tree = parser.parse("x = 1").orElseThrow();
+             Node root = tree.rootNode()) {
+            String kind = root.kind();
+            assertNotNull(kind, "kind() must not return null");
+            assertFalse(kind.startsWith("\""),
+                "kind() must not be JSON-quoted — got: " + kind);
+            assertEquals("module", kind,
+                "Python root node kind must be 'module'");
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds two regression tests to `TreeTraversalTest` covering the string-return paths fixed in alef 0.25.47.

Before that version, `node.kind()` and `node.toSexp()` were routed through `serde_json::to_string` in the JNI shim, so callers received JSON-quoted output (`"\"module\""` instead of `"module"`, `"\"(module ...)\""` instead of `"(module ...)"`). The fixed shim passes the raw `&str`/`String` directly. These tests would fail against the old code.

Identified during post-hoc review of the now-closed PR #151.

## Test plan

- [ ] `testKindReturnsPlainStringNotJson` — asserts `root.kind()` equals `"module"` exactly
- [ ] `testToSexpReturnsPlainSexpNotJson` — asserts `root.toSexp()` starts with `(` and is not JSON-quoted
- [ ] Java e2e CI passes