### PR TITLE
fix(ruby): expose parser API methods

### DIFF
--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -1796,14 +1796,26 @@ unsafe impl IntoValueFromNative for Parser {}
 
 impl magnus::TryConvert for Parser {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Parser = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Parser> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
 unsafe impl TryConvertOwned for Parser {}
 
 impl Parser {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(tree_sitter_language_pack::Parser::new())),
+        }
+    }
+
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(tree_sitter_language_pack::Parser::default())),
+        }
+    }
+
     fn set_language(&self, name: String) -> Result<(), Error> {
         self.inner.lock().unwrap().set_language(&name).map_err(|e| {
             magnus::Error::new(
@@ -1845,8 +1857,8 @@ unsafe impl IntoValueFromNative for Tree {}
 
 impl magnus::TryConvert for Tree {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Tree = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Tree> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -1876,8 +1888,8 @@ unsafe impl IntoValueFromNative for Node {}
 
 impl magnus::TryConvert for Node {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Node = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Node> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -1985,8 +1997,8 @@ unsafe impl IntoValueFromNative for TreeCursor {}
 
 impl magnus::TryConvert for TreeCursor {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &TreeCursor = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<TreeCursor> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2266,8 +2278,8 @@ unsafe impl IntoValueFromNative for LanguageRegistry {}
 
 impl magnus::TryConvert for LanguageRegistry {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &LanguageRegistry = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<LanguageRegistry> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2324,8 +2336,8 @@ unsafe impl IntoValueFromNative for DownloadManager {}
 
 impl magnus::TryConvert for DownloadManager {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &DownloadManager = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<DownloadManager> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2367,8 +2379,8 @@ unsafe impl IntoValueFromNative for Language {}
 
 impl magnus::TryConvert for Language {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Language = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Language> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -3935,6 +3947,18 @@ fn ruby_init(ruby: &Ruby) -> Result<(), Error> {
     class.define_method("end", method!(ByteRange::end, 0))?;
 
     let class = module.define_class("Parser", ruby.class_object())?;
+
+    class.define_singleton_method("new", function!(Parser::new, 0))?;
+
+    class.define_singleton_method("default", function!(Parser::default, 0))?;
+
+    class.define_method("set_language", method!(Parser::set_language, 1))?;
+
+    class.define_method("parse", method!(Parser::parse, 1))?;
+
+    class.define_method("parse_bytes", method!(Parser::parse_bytes, 1))?;
+
+    class.define_method("reset", method!(Parser::reset, 0))?;
 
     let class = module.define_class("Tree", ruby.class_object())?;
 


### PR DESCRIPTION
## Summary

Fixes #164.

This exposes the Ruby parser API methods needed for Ruby integrations to parse through TSLP's intended on-demand grammar interface:

- `TreeSitterLanguagePack::Parser.new`
- `TreeSitterLanguagePack::Parser.default`
- `Parser#set_language`
- `Parser#parse`
- `Parser#parse_bytes`
- `Parser#reset`

It also updates wrapper `TryConvert` implementations to convert through `magnus::typed_data::Obj<T>` for the Ruby typed-data wrappers, avoiding failed/recursive conversion for wrapped `Parser`, `Tree`, `Node`, `TreeCursor`, `LanguageRegistry`, `DownloadManager`, and `Language` objects.

## Why

TreeHaver needs to use TSLP via the actual Ruby parser API instead of probing TSLP cache paths. Cache-path probing is unreliable from a cold start because grammars are loaded on demand by TSLP. With this patch, Ruby can do:

```ruby
require "tree_sitter_language_pack"
parser = TreeSitterLanguagePack.get_parser("json")
tree = parser.parse('{"a":1}')
tree.root_node.kind # => "document"
```

## Validation

Validated locally in the Ruby package:

```console
bundle exec rake compile
```

And with a direct Ruby probe:

```ruby
require "tree_sitter_language_pack"
parser = TreeSitterLanguagePack.get_parser("json")
tree = parser.parse('{"a":1}')
tree.root_node.kind # => "document"
```
