### PR TITLE
fix(ruby): expose parser API methods

### DIFF
--- a/crates/ts-pack-core/language_definitions.json
+++ b/crates/ts-pack-core/language_definitions.json
@@ -184,7 +184,7 @@
     "extensions": ["cedar"],
     "generate": true,
     "repo": "https://github.com/DuskSystems/tree-sitter-cedar",
-    "rev": "ac1fe619df3d4af9f797903d4b8852f12082a0d5"
+    "rev": "05f0223c406d4e9a91d55143dbe63e7788dfa29d"
   },
   "cedarschema": {
     "abi_version": 14,
@@ -192,7 +192,7 @@
     "extensions": ["cedarschema"],
     "generate": true,
     "repo": "https://github.com/DuskSystems/tree-sitter-cedar",
-    "rev": "ac1fe619df3d4af9f797903d4b8852f12082a0d5"
+    "rev": "05f0223c406d4e9a91d55143dbe63e7788dfa29d"
   },
   "cel": {
     "abi_version": 14,

--- a/e2e/ruby/spec/parsing_spec.rb
+++ b/e2e/ruby/spec/parsing_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe "parsing" do
 
     expect(result).not_to(be_nil)
   end
+
+  it "parser_parse: parses source through the parser API" do
+    parser = TreeSitterLanguagePack.get_parser("json")
+    tree = parser.parse('{"a":1}')
+
+    expect(tree.root_node.kind).to(eq("document"))
+  end
+
+  it "parser_parse_bytes: parses string bytes through the parser API" do
+    parser = TreeSitterLanguagePack.get_parser("json")
+    tree = parser.parse_bytes('{"a":1}')
+
+    expect(tree.root_node.kind).to(eq("document"))
+  end
 end

--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -1834,11 +1834,11 @@ impl Parser {
             .map(|v| Tree { inner: Arc::new(v) })
     }
 
-    fn parse_bytes(&self, source: Vec<u8>) -> Option<Tree> {
+    fn parse_bytes(&self, source: String) -> Option<Tree> {
         self.inner
             .lock()
             .unwrap()
-            .parse_bytes(&source)
+            .parse_bytes(source.as_bytes())
             .map(|v| Tree { inner: Arc::new(v) })
     }
 

--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -1796,14 +1796,26 @@ unsafe impl IntoValueFromNative for Parser {}
 
 impl magnus::TryConvert for Parser {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Parser = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Parser> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
 unsafe impl TryConvertOwned for Parser {}
 
 impl Parser {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(tree_sitter_language_pack::Parser::new())),
+        }
+    }
+
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(tree_sitter_language_pack::Parser::default())),
+        }
+    }
+
     fn set_language(&self, name: String) -> Result<(), Error> {
         self.inner.lock().unwrap().set_language(&name).map_err(|e| {
             magnus::Error::new(
@@ -1845,8 +1857,8 @@ unsafe impl IntoValueFromNative for Tree {}
 
 impl magnus::TryConvert for Tree {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Tree = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Tree> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -1876,8 +1888,8 @@ unsafe impl IntoValueFromNative for Node {}
 
 impl magnus::TryConvert for Node {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Node = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Node> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -1985,8 +1997,8 @@ unsafe impl IntoValueFromNative for TreeCursor {}
 
 impl magnus::TryConvert for TreeCursor {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &TreeCursor = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<TreeCursor> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2266,8 +2278,8 @@ unsafe impl IntoValueFromNative for LanguageRegistry {}
 
 impl magnus::TryConvert for LanguageRegistry {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &LanguageRegistry = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<LanguageRegistry> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2324,8 +2336,8 @@ unsafe impl IntoValueFromNative for DownloadManager {}
 
 impl magnus::TryConvert for DownloadManager {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &DownloadManager = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<DownloadManager> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -2367,8 +2379,8 @@ unsafe impl IntoValueFromNative for Language {}
 
 impl magnus::TryConvert for Language {
     fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
-        let r: &Language = magnus::TryConvert::try_convert(val)?;
-        Ok(r.clone())
+        let r: magnus::typed_data::Obj<Language> = magnus::TryConvert::try_convert(val)?;
+        Ok((*r).clone())
     }
 }
 
@@ -3935,6 +3947,18 @@ fn ruby_init(ruby: &Ruby) -> Result<(), Error> {
     class.define_method("end", method!(ByteRange::end, 0))?;
 
     let class = module.define_class("Parser", ruby.class_object())?;
+
+    class.define_singleton_method("new", function!(Parser::new, 0))?;
+
+    class.define_singleton_method("default", function!(Parser::default, 0))?;
+
+    class.define_method("set_language", method!(Parser::set_language, 1))?;
+
+    class.define_method("parse", method!(Parser::parse, 1))?;
+
+    class.define_method("parse_bytes", method!(Parser::parse_bytes, 1))?;
+
+    class.define_method("reset", method!(Parser::reset, 0))?;
 
     let class = module.define_class("Tree", ruby.class_object())?;
 

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -184,7 +184,7 @@
     "extensions": ["cedar"],
     "generate": true,
     "repo": "https://github.com/DuskSystems/tree-sitter-cedar",
-    "rev": "ac1fe619df3d4af9f797903d4b8852f12082a0d5"
+    "rev": "05f0223c406d4e9a91d55143dbe63e7788dfa29d"
   },
   "cedarschema": {
     "abi_version": 14,
@@ -192,7 +192,7 @@
     "extensions": ["cedarschema"],
     "generate": true,
     "repo": "https://github.com/DuskSystems/tree-sitter-cedar",
-    "rev": "ac1fe619df3d4af9f797903d4b8852f12082a0d5"
+    "rev": "05f0223c406d4e9a91d55143dbe63e7788dfa29d"
   },
   "cel": {
     "abi_version": 14,

--- a/test_apps/ruby/spec/parsing_spec.rb
+++ b/test_apps/ruby/spec/parsing_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe "parsing" do
 
     expect(result).not_to(be_nil)
   end
+
+  it "parser_parse: parses source through the parser API" do
+    parser = TreeSitterLanguagePack.get_parser("json")
+    tree = parser.parse('{"a":1}')
+
+    expect(tree.root_node.kind).to(eq("document"))
+  end
+
+  it "parser_parse_bytes: parses string bytes through the parser API" do
+    parser = TreeSitterLanguagePack.get_parser("json")
+    tree = parser.parse_bytes('{"a":1}')
+
+    expect(tree.root_node.kind).to(eq("document"))
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #164.

This exposes the Ruby parser API methods needed for Ruby integrations to parse through TSLP's intended on-demand grammar interface:

- `TreeSitterLanguagePack::Parser.new`
- `TreeSitterLanguagePack::Parser.default`
- `Parser#set_language`
- `Parser#parse`
- `Parser#parse_bytes`
- `Parser#reset`

It also updates wrapper `TryConvert` implementations to convert through `magnus::typed_data::Obj<T>` for the Ruby typed-data wrappers, avoiding failed/recursive conversion for wrapped `Parser`, `Tree`, `Node`, `TreeCursor`, `LanguageRegistry`, `DownloadManager`, and `Language` objects.

## CI Repair

This PR also updates the `cedar`/`cedarschema` grammar revision in both language definition files. The previous pinned commit (`ac1fe619df3d4af9f797903d4b8852f12082a0d5`) is no longer checkoutable from `DuskSystems/tree-sitter-cedar`, which made multiple `Clone vendors` CI jobs fail before the Ruby changes could be tested. The new revision (`05f0223c406d4e9a91d55143dbe63e7788dfa29d`) is the current reachable `main` commit from that grammar repository.

## Why

TreeHaver needs to use TSLP via the actual Ruby parser API instead of probing TSLP cache paths. Cache-path probing is unreliable from a cold start because grammars are loaded on demand by TSLP. With this patch, Ruby can do:

```ruby
require "tree_sitter_language_pack"
parser = TreeSitterLanguagePack.get_parser("json")
tree = parser.parse('{"a":1}')
tree.root_node.kind # => "document"
```

## Validation

Validated locally in the Ruby package:

```console
bundle exec rake compile
```

And with a direct Ruby probe:

```ruby
require "tree_sitter_language_pack"
parser = TreeSitterLanguagePack.get_parser("json")
tree = parser.parse('{"a":1}')
tree.root_node.kind # => "document"
```

Also validated `Parser#parse_bytes` with Ruby `String` input and ran:

```console
bundle exec rspec spec/parsing_spec.rb
```

in `e2e/ruby`.
