### PR TITLE
fix(ruby): parser bindings

### DIFF
--- a/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
+++ b/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.12.5"
+version = "1.13.0"
 dependencies = [
  "ahash",
  "cc",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "ts-pack-core-rb"
-version = "1.12.5"
+version = "1.13.0"
 dependencies = [
  "magnus",
  "rb-sys",

--- a/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
+++ b/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "ahash",
  "cc",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "ts-pack-core-rb"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "magnus",
  "rb-sys",

--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -3982,6 +3982,14 @@ fn ruby_init(ruby: &Ruby) -> Result<(), Error> {
 
     let class = module.define_class("Parser", ruby.class_object())?;
 
+    class.define_method("set_language", method!(Parser::set_language, 1))?;
+
+    class.define_method("parse", method!(Parser::parse, 1))?;
+
+    class.define_method("parse_bytes", method!(Parser::parse_bytes, 1))?;
+
+    class.define_method("reset", method!(Parser::reset, 0))?;
+
     let class = module.define_class("Tree", ruby.class_object())?;
 
     class.define_method("root_node", method!(Tree::root_node, 0))?;

--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -19,9 +19,8 @@
     clippy::clone_on_copy
 )]
 
-use magnus::{function, method, prelude::*, try_convert::TryConvertOwned, Error, IntoValueFromNative, Ruby};
-use std::sync::Mutex;
-use std::sync::{Arc, MutexGuard};
+use magnus::{Error, IntoValueFromNative, RString, Ruby, function, method, prelude::*, try_convert::TryConvertOwned};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 fn json_to_ruby(handle: &Ruby, val: serde_json::Value) -> magnus::Value {
     use magnus::IntoValue;
@@ -1789,7 +1788,7 @@ impl ByteRange {
 #[derive(Clone)]
 #[magnus::wrap(class = "TreeSitterLanguagePack::Parser")]
 pub struct Parser {
-    inner: Arc<std::sync::Mutex<tree_sitter_language_pack::Parser>>,
+    inner: Arc<Mutex<tree_sitter_language_pack::Parser>>,
 }
 
 unsafe impl IntoValueFromNative for Parser {}
@@ -1805,21 +1804,15 @@ unsafe impl TryConvertOwned for Parser {}
 
 impl Parser {
     fn lock_inner(&self) -> Result<MutexGuard<'_, tree_sitter_language_pack::Parser>, Error> {
-        self.inner.lock().map_err(|_| {
-            magnus::Error::new(
-                unsafe { Ruby::get_unchecked() }.exception_runtime_error(),
-                "parser mutex poisoned",
-            )
-        })
+        self.inner.lock().map_err(|_| runtime_error(
+            "parser mutex poisoned: another thread panicked while holding the parser lock; discard this parser and request a new one"
+        ))
     }
 
     fn set_language(&self, name: String) -> Result<(), Error> {
-        self.lock_inner()?.set_language(&name).map_err(|e| {
-            magnus::Error::new(
-                unsafe { Ruby::get_unchecked() }.exception_runtime_error(),
-                e.to_string(),
-            )
-        })?;
+        self.lock_inner()?
+            .set_language(&name)
+            .map_err(|e| runtime_error(e.to_string()))?;
         Ok(())
     }
 
@@ -1827,7 +1820,8 @@ impl Parser {
         Ok(self.lock_inner()?.parse(&source).map(|v| Tree { inner: Arc::new(v) }))
     }
 
-    fn parse_bytes(&self, source: Vec<u8>) -> Result<Option<Tree>, Error> {
+    fn parse_bytes(&self, source: RString) -> Result<Option<Tree>, Error> {
+        let source = unsafe { source.as_slice().to_vec() };
         Ok(self
             .lock_inner()?
             .parse_bytes(&source)
@@ -3714,8 +3708,14 @@ impl From<tree_sitter_language_pack::DiagnosticSeverity> for DiagnosticSeverity 
 /// Convert a `tree_sitter_language_pack::error::Error` error to a Magnus runtime error.
 #[allow(dead_code)]
 fn error_to_magnus_err(e: tree_sitter_language_pack::error::Error) -> magnus::Error {
-    let msg = e.to_string();
-    magnus::Error::new(unsafe { magnus::Ruby::get_unchecked() }.exception_runtime_error(), msg)
+    runtime_error(e.to_string())
+}
+
+fn runtime_error(message: impl Into<String>) -> magnus::Error {
+    magnus::Error::new(
+        unsafe { magnus::Ruby::get_unchecked() }.exception_runtime_error(),
+        message.into(),
+    )
 }
 
 #[magnus::init]

--- a/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
+++ b/packages/ruby/ext/ts_pack_core_rb/src/lib.rs
@@ -19,9 +19,9 @@
     clippy::clone_on_copy
 )]
 
-use magnus::{Error, IntoValueFromNative, Ruby, function, method, prelude::*, try_convert::TryConvertOwned};
-use std::sync::Arc;
+use magnus::{function, method, prelude::*, try_convert::TryConvertOwned, Error, IntoValueFromNative, Ruby};
 use std::sync::Mutex;
+use std::sync::{Arc, MutexGuard};
 
 fn json_to_ruby(handle: &Ruby, val: serde_json::Value) -> magnus::Value {
     use magnus::IntoValue;
@@ -1804,8 +1804,17 @@ impl magnus::TryConvert for Parser {
 unsafe impl TryConvertOwned for Parser {}
 
 impl Parser {
+    fn lock_inner(&self) -> Result<MutexGuard<'_, tree_sitter_language_pack::Parser>, Error> {
+        self.inner.lock().map_err(|_| {
+            magnus::Error::new(
+                unsafe { Ruby::get_unchecked() }.exception_runtime_error(),
+                "parser mutex poisoned",
+            )
+        })
+    }
+
     fn set_language(&self, name: String) -> Result<(), Error> {
-        self.inner.lock().unwrap().set_language(&name).map_err(|e| {
+        self.lock_inner()?.set_language(&name).map_err(|e| {
             magnus::Error::new(
                 unsafe { Ruby::get_unchecked() }.exception_runtime_error(),
                 e.to_string(),
@@ -1814,24 +1823,20 @@ impl Parser {
         Ok(())
     }
 
-    fn parse(&self, source: String) -> Option<Tree> {
-        self.inner
-            .lock()
-            .unwrap()
-            .parse(&source)
-            .map(|v| Tree { inner: Arc::new(v) })
+    fn parse(&self, source: String) -> Result<Option<Tree>, Error> {
+        Ok(self.lock_inner()?.parse(&source).map(|v| Tree { inner: Arc::new(v) }))
     }
 
-    fn parse_bytes(&self, source: Vec<u8>) -> Option<Tree> {
-        self.inner
-            .lock()
-            .unwrap()
+    fn parse_bytes(&self, source: Vec<u8>) -> Result<Option<Tree>, Error> {
+        Ok(self
+            .lock_inner()?
             .parse_bytes(&source)
-            .map(|v| Tree { inner: Arc::new(v) })
+            .map(|v| Tree { inner: Arc::new(v) }))
     }
 
-    fn reset(&self) -> () {
-        self.inner.lock().unwrap().reset()
+    fn reset(&self) -> Result<(), Error> {
+        self.lock_inner()?.reset();
+        Ok(())
     }
 }
 

--- a/packages/ruby/spec/parser_spec.rb
+++ b/packages/ruby/spec/parser_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe TreeSitterLanguagePack::Parser do
     expect(parser).to respond_to(:parse_bytes)
     expect(parser).to respond_to(:reset)
 
+    expect(parser.set_language("json")).to be_nil
+
     tree = parser.parse('{"name":"tslp"}')
 
     expect(tree).not_to be_nil
     expect(tree.root_node.kind).not_to be_empty
 
-    bytes_tree = parser.parse_bytes('{"byte":true}'.bytes)
+    bytes_tree = parser.parse_bytes('{"byte":true}'.b)
 
     expect(bytes_tree).not_to be_nil
     expect(bytes_tree.root_node.kind).not_to be_empty

--- a/packages/ruby/spec/parser_spec.rb
+++ b/packages/ruby/spec/parser_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "tree_sitter_language_pack"
+
+RSpec.describe TreeSitterLanguagePack::Parser do
+  it "exposes parser methods and parses source" do
+    parser = TreeSitterLanguagePack.get_parser("json")
+
+    expect(parser).to respond_to(:set_language)
+    expect(parser).to respond_to(:parse)
+    expect(parser).to respond_to(:parse_bytes)
+    expect(parser).to respond_to(:reset)
+
+    tree = parser.parse('{"name":"tslp"}')
+
+    expect(tree).not_to be_nil
+    expect(tree.root_node.kind).not_to be_empty
+  end
+end

--- a/packages/ruby/spec/parser_spec.rb
+++ b/packages/ruby/spec/parser_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe TreeSitterLanguagePack::Parser do
 
     expect(tree).not_to be_nil
     expect(tree.root_node.kind).not_to be_empty
+
+    bytes_tree = parser.parse_bytes('{"byte":true}'.bytes)
+
+    expect(bytes_tree).not_to be_nil
+    expect(bytes_tree.root_node.kind).not_to be_empty
+
+    expect(parser.reset).to be_nil
   end
 end


### PR DESCRIPTION
This PR fixes the remaining Ruby package parser-binding regression after the v1.13.x release line.

The parser methods already existed in the Rust wrapper and the generated RBS advertised them, but `ruby_init` did not bind those methods. That made `TreeSitterLanguagePack.get_parser("json")` return an object that could not parse from Ruby.

Changes:

- expose `TreeSitterLanguagePack::Parser#set_language`, `#parse`, `#parse_bytes`, and `#reset` to Ruby
- map poisoned parser mutexes to a Ruby `RuntimeError` instead of panicking
- keep `parse_bytes` aligned with the RBS by accepting a Ruby `String`
- exercise `set_language`, `parse`, `parse_bytes`, and `reset` from Ruby specs

Note: the Ruby version metadata fix is already present on `main` and is no longer part of this PR.

Local verification:

```sh
cd packages/ruby
bundle exec rake spec
# 1 example, 0 failures
```

Closes #168
