### PR TITLE
fix(ruby): package native gems per Ruby ABI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -706,6 +706,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     env:
+      BUNDLER_VERSION: "4.0.7"
       RB_SYS_CARGO_PROFILE: release
     strategy:
       fail-fast: false
@@ -742,42 +743,145 @@ jobs:
           use-sccache: "false"
           install-llvm-cov: "false"
 
-      - name: Setup Ruby
+      - name: Rewrite native dependencies
+        uses: xberg-io/actions/rewrite-native-deps@v1
+        with:
+          lang: ruby
+
+      - name: Setup Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler: none
+          bundler-cache: false
+
+      - name: Stage Ruby 3.2 native extension
+        run: |
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+          ruby scripts/publish/ruby/stage-native-abi.rb
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/packages/ruby/target
+
+      - name: Setup Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler: none
+          bundler-cache: false
+
+      - name: Stage Ruby 3.3 native extension
+        run: |
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+          ruby scripts/publish/ruby/stage-native-abi.rb
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/packages/ruby/target
+
+      - name: Setup Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
           bundler: none
           bundler-cache: false
 
-      - name: Install Bundler
-        run: gem install bundler --no-document && bundler --version
-
-      - name: Install Ruby dependencies
-        working-directory: packages/ruby
+      - name: Stage Ruby 3.4 native extension
         run: |
-          bundle config set --local path vendor/bundle
-          bundle check || bundle install
-
-      - name: Rewrite native dependencies
-        uses: xberg-io/actions/rewrite-native-deps@v1
-        with:
-          lang: ruby
-
-      - name: Compile native extension
-        working-directory: packages/ruby
-        timeout-minutes: 60
-        run: |
-          echo "Compiling native extension..."
-          bundle exec rake compile
-          echo "Native extension compiled successfully"
-          echo "=== Native libraries ==="
-          find lib -name '*.so' -o -name '*.bundle' -o -name '*.dylib' 2>/dev/null | head -20
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+          ruby scripts/publish/ruby/stage-native-abi.rb
         env:
           PROJECT_ROOT: ${{ github.workspace }}
           CARGO_TARGET_DIR: ${{ github.workspace }}/packages/ruby/target
 
+      - name: Setup Ruby 3.5
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.5"
+          bundler: none
+          bundler-cache: false
+
+      - name: Stage Ruby 3.5 native extension
+        run: |
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+          ruby scripts/publish/ruby/stage-native-abi.rb
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/packages/ruby/target
+
+      - name: Setup Ruby 4.0
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler: none
+          bundler-cache: false
+
+      - name: Stage Ruby 4.0 native extension
+        run: |
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+          ruby scripts/publish/ruby/stage-native-abi.rb
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/packages/ruby/target
+
+      - name: List staged native libraries
+        working-directory: packages/ruby
+        run: find lib/ts_pack_core_rb -type f | sort
+
       - name: Build platform gem
         run: ruby scripts/publish/ruby/build-native-gem.rb "${{ matrix.ruby_platform }}"
+
+      - name: Verify platform gem on Ruby 4.0
+        run: |
+          gem install packages/ruby/tree_sitter_language_pack-*.gem --no-document
+          ruby -e 'require "tree_sitter_language_pack"; abort("parse failed") unless TreeSitterLanguagePack.get_parser("json").parse("{}").root_node.kind == "document"'
+
+      - name: Setup Ruby 3.5 for platform gem verification
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.5"
+          bundler: none
+          bundler-cache: false
+
+      - name: Verify platform gem on Ruby 3.5
+        run: |
+          gem install packages/ruby/tree_sitter_language_pack-*.gem --no-document
+          ruby -e 'require "tree_sitter_language_pack"; abort("parse failed") unless TreeSitterLanguagePack.get_parser("json").parse("{}").root_node.kind == "document"'
+
+      - name: Setup Ruby 3.4 for platform gem verification
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler: none
+          bundler-cache: false
+
+      - name: Verify platform gem on Ruby 3.4
+        run: |
+          gem install packages/ruby/tree_sitter_language_pack-*.gem --no-document
+          ruby -e 'require "tree_sitter_language_pack"; abort("parse failed") unless TreeSitterLanguagePack.get_parser("json").parse("{}").root_node.kind == "document"'
+
+      - name: Setup Ruby 3.3 for platform gem verification
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler: none
+          bundler-cache: false
+
+      - name: Verify platform gem on Ruby 3.3
+        run: |
+          gem install packages/ruby/tree_sitter_language_pack-*.gem --no-document
+          ruby -e 'require "tree_sitter_language_pack"; abort("parse failed") unless TreeSitterLanguagePack.get_parser("json").parse("{}").root_node.kind == "document"'
+
+      - name: Setup Ruby 3.2 for platform gem verification
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler: none
+          bundler-cache: false
+
+      - name: Verify platform gem on Ruby 3.2
+        run: |
+          gem install packages/ruby/tree_sitter_language_pack-*.gem --no-document
+          ruby -e 'require "tree_sitter_language_pack"; abort("parse failed") unless TreeSitterLanguagePack.get_parser("json").parse("{}").root_node.kind == "document"'
 
       - name: Verify gem was built
         working-directory: packages/ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ruby**: platform-specific native gems now package one native extension per supported Ruby ABI and
+  load the extension matching the current runtime. This keeps precompiled gems usable on Ruby 3.2,
+  3.3, 3.4, 3.5, and Ruby 4 while avoiding `Parser#parse` self-conversion `TypeError`s from loading
+  an extension compiled against a different Ruby ABI.
+
 ## [1.13.2] - 2026-07-20
 
 ### Fixed

--- a/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
+++ b/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "ahash",
  "cc",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "ts-pack-core-rb"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "magnus",
  "rb-sys",

--- a/packages/ruby/lib/ts_pack_core_rb.rb
+++ b/packages/ruby/lib/ts_pack_core_rb.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+extension_name = "ts_pack_core_rb"
+dlext = RbConfig::CONFIG.fetch("DLEXT")
+ruby_abi = RbConfig::CONFIG.fetch("ruby_version")
+
+candidates = [
+  File.expand_path("#{extension_name}/#{ruby_abi}/#{extension_name}.#{dlext}", __dir__),
+  File.expand_path("#{extension_name}.#{dlext}", __dir__)
+]
+
+native_extension = candidates.find { |path| File.file?(path) }
+
+unless native_extension
+  raise(
+    LoadError,
+    "cannot find #{extension_name} native extension for Ruby ABI #{ruby_abi}; " \
+      "searched: #{candidates.join(", ")}"
+  )
+end
+
+require native_extension

--- a/scripts/publish/ruby/build-native-gem.rb
+++ b/scripts/publish/ruby/build-native-gem.rb
@@ -16,9 +16,13 @@ end
 gem_dir = File.expand_path("../../../packages/ruby", __dir__)
 Dir.chdir(gem_dir)
 
-native_extensions = Dir.glob("lib/**/*.{so,bundle,dylib}")
+staged_native_glob = "lib/ts_pack_core_rb/**/*.{so,bundle,dylib}"
+native_extensions = Dir.glob(staged_native_glob)
 if native_extensions.empty?
-  abort("ERROR: No compiled native extensions found in lib/. Run 'rake compile' first.")
+  abort(
+    "ERROR: No staged native extensions found under lib/ts_pack_core_rb/. " \
+      "Run scripts/publish/ruby/stage-native-abi.rb for each supported Ruby ABI first."
+  )
 end
 
 puts("Found native extensions: #{native_extensions.join(", ")}")
@@ -27,14 +31,17 @@ spec = Gem::Specification.load("tree_sitter_language_pack.gemspec")
 abort("ERROR: Could not load tree_sitter_language_pack.gemspec") unless spec
 
 spec.platform = Gem::Platform.new(platform)
-
 spec.extensions = []
 
 native_extensions.each do |ext|
   spec.files << ext unless spec.files.include?(ext)
 end
 
-spec.files.reject! { |f| f.start_with?("vendor/") || f.start_with?("ext/") }
+spec.files.reject! do |file|
+  file.start_with?("vendor/") ||
+    file.start_with?("ext/") ||
+    file.match?(%r{\Alib/ts_pack_core_rb\.(?:so|bundle|dylib)\z})
+end
 
 spec.dependencies.reject! { |d| d.name == "rb_sys" }
 

--- a/scripts/publish/ruby/stage-native-abi.rb
+++ b/scripts/publish/ruby/stage-native-abi.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "rbconfig"
+require "rubygems"
+
+gem_dir = File.expand_path("../../../packages/ruby", __dir__)
+Dir.chdir(gem_dir)
+
+ruby_abi = RbConfig::CONFIG.fetch("ruby_version")
+bundler_version = File
+  .read("Gemfile.lock")
+  .match(/\nBUNDLED WITH\n\s+(\S+)\n/)
+  &.[](1)
+abort("ERROR: Could not determine Bundler version from Gemfile.lock") unless bundler_version
+
+unless Gem::Specification.find_all_by_name("bundler", bundler_version).any?
+  abort(
+    "ERROR: Bundler #{bundler_version} is required by Gemfile.lock but is not installed. " \
+      "Run `gem install bundler -v #{bundler_version} --no-document` first."
+  )
+end
+
+bundle = ["bundle", "_#{bundler_version}_"]
+bundle_path = File.join("vendor", "bundle", ruby_abi)
+bundle_env = {"BUNDLE_PATH" => bundle_path}
+staged_root = File.join("lib", "ts_pack_core_rb")
+preserved_staged_root = File.join("tmp", "ruby-native-abi-stage")
+
+system(bundle_env, *bundle, "check") ||
+  system(bundle_env, *bundle, "install", exception: true)
+
+FileUtils.rm_rf(preserved_staged_root)
+if Dir.exist?(staged_root)
+  FileUtils.mkdir_p(File.dirname(preserved_staged_root))
+  FileUtils.mv(staged_root, preserved_staged_root)
+end
+
+Dir.glob("lib/ts_pack_core_rb.{so,bundle,dylib}").each { |path| FileUtils.rm_f(path) }
+
+begin
+  system(bundle_env, *bundle, "exec", "rake", "compile", exception: true)
+ensure
+  if Dir.exist?(preserved_staged_root) && !Dir.exist?(staged_root)
+    FileUtils.mkdir_p(File.dirname(staged_root))
+    FileUtils.mv(preserved_staged_root, staged_root)
+  end
+end
+
+native_extension = Dir.glob("lib/ts_pack_core_rb.{so,bundle,dylib}").first
+abort("ERROR: No compiled native extension found for Ruby ABI #{ruby_abi}") unless native_extension
+
+destination_dir = File.join("lib", "ts_pack_core_rb", ruby_abi)
+FileUtils.mkdir_p(destination_dir)
+destination = File.join(destination_dir, File.basename(native_extension))
+FileUtils.cp(native_extension, destination)
+
+puts("Staged Ruby ABI #{ruby_abi} native extension: #{destination}")


### PR DESCRIPTION
Fixes #170.

## Summary

Ruby platform gems now package native extensions per Ruby ABI instead of shipping a single extension for each OS/CPU platform. The runtime loader selects the extension matching `RbConfig::CONFIG["ruby_version"]`, so the same platform gem can support Ruby 3.2, 3.3, 3.4, 3.5, and 4.0 without loading an extension built for a different ABI.

The publish workflow now stages native payloads for every supported Ruby ABI and smoke-tests the built platform gem on each Ruby version before upload.

NOTE: @Goldziher There was never a ruby 3.5.0 release, but there was a 3.5.0 preview release. Not sure if it matters to support it at all. The 3.5 build could easily be removed. In the very next preview release it became Ruby 4.0.
https://www.ruby-lang.org/en/news/2025/04/18/ruby-3-5-0-preview1-released/

## Publishing behavior: before vs after

The set of RubyGems artifacts does **not** change. The next version would still be published as one source gem plus four OS/CPU platform gems.

### Before: 1.13.2

RubyGems showed these Ruby artifacts:

| Version | Platform | What the gem contained |
| --- | --- | --- |
| `1.13.2` | source / ruby | Source gem; native extension is built locally during install. |
| `1.13.2` | `x86_64-darwin` | One precompiled native extension for macOS x86_64, built with the release runner's Ruby ABI. |
| `1.13.2` | `arm64-darwin` | One precompiled native extension for macOS arm64, built with the release runner's Ruby ABI. |
| `1.13.2` | `x86_64-linux` | One precompiled native extension for Linux x86_64, built with the release runner's Ruby ABI. |
| `1.13.2` | `aarch64-linux` | One precompiled native extension for Linux aarch64, built with the release runner's Ruby ABI. |

Because RubyGems platform matching does not distinguish Ruby ABI versions, Ruby 4 could install the same `x86_64-linux` gem that was built under Ruby 3.4 and then load a mismatched native extension.

### After: next release, for example 1.13.3

RubyGems would still show the same artifact shape:

| Version | Platform | What the gem contains |
| --- | --- | --- |
| `1.13.3` | source / ruby | Source gem; native extension is built locally during install. |
| `1.13.3` | `x86_64-darwin` | Precompiled native extensions for Ruby ABI `3.2.0`, `3.3.0`, `3.4.0`, `3.5.0`, and `4.0.0` on macOS x86_64. |
| `1.13.3` | `arm64-darwin` | Precompiled native extensions for Ruby ABI `3.2.0`, `3.3.0`, `3.4.0`, `3.5.0`, and `4.0.0` on macOS arm64. |
| `1.13.3` | `x86_64-linux` | Precompiled native extensions for Ruby ABI `3.2.0`, `3.3.0`, `3.4.0`, `3.5.0`, and `4.0.0` on Linux x86_64. |
| `1.13.3` | `aarch64-linux` | Precompiled native extensions for Ruby ABI `3.2.0`, `3.3.0`, `3.4.0`, `3.5.0`, and `4.0.0` on Linux aarch64. |

Inside each platform gem, the native files are staged like this:

```text
lib/ts_pack_core_rb/3.2.0/ts_pack_core_rb.<ext>
lib/ts_pack_core_rb/3.3.0/ts_pack_core_rb.<ext>
lib/ts_pack_core_rb/3.4.0/ts_pack_core_rb.<ext>
lib/ts_pack_core_rb/3.5.0/ts_pack_core_rb.<ext>
lib/ts_pack_core_rb/4.0.0/ts_pack_core_rb.<ext>
```

At runtime, `lib/ts_pack_core_rb.rb` loads the file for the current `RbConfig::CONFIG["ruby_version"]`. The expected user-visible effect is that RubyGems still resolves the same platform gem names, but Ruby 3.2 through Ruby 4.0 load ABI-matching native extensions from inside that gem. Exact compressed gem sizes will depend on the final release build, but each platform gem will be larger than 1.13.2 because it carries five native ABI payloads instead of one.

## Why

RubyGems selects the same `x86_64-linux` platform gem across Ruby ABI versions. The released 1.13.2 platform gem was built under Ruby 3.4, but Ruby 4.0 also installed it. Loading that Ruby-3-built native extension under Ruby 4 caused `Parser#parse` to fail with:

```text
TypeError: no implicit conversion of TreeSitterLanguagePack::Parser into TreeSitterLanguagePack::Parser
```

Direct probes showed this was not JSON-specific; every tested language failed the same way when the mismatched platform extension was loaded. Source builds under Ruby 4 worked, so the problem was platform-gem packaging rather than parser generation.

## Validation

- `alef verify --exit-code`
- `TSLP_LANGUAGES=json task ruby:test`
- Built a reduced local `x86_64-linux` platform gem with Ruby 4.0 and Ruby 3.4 ABI payloads
- Installed that same platform gem in isolated Ruby 4.0 and Ruby 3.4 gem homes
- Verified `TreeSitterLanguagePack.get_parser("json").parse("{}")` returns a `document` root under both Rubies
