### PR TITLE
fix: ARM64 native-loading drift (Java + Go) and brightscript pin bump

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -852,7 +852,6 @@ jobs:
       - name: Run Java unit tests
         working-directory: packages/java
         run: mvn test
-        env:
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/ci-sanitize.yaml
+++ b/.github/workflows/ci-sanitize.yaml
@@ -170,8 +170,24 @@ jobs:
             -fno-omit-frame-pointer
             -fno-common
             -g
-          RUSTFLAGS: -Clink-arg=-fsanitize=address,undefined -Cforce-frame-pointers=yes
-        run: cargo build --locked -p ts-pack-cli --bin ts-pack 2>&1 | tee build.log
+          # rustc links with `-nodefaultlibs`, which suppresses exactly the libraries the
+          # `-fsanitize=` driver flag exists to add, so the sanitizer runtimes have to be
+          # named explicitly or the link fails on undefined __asan_/__ubsan_ symbols. ~keep
+          RUSTFLAGS: >-
+            -Clink-arg=-fsanitize=address,undefined
+            -Clink-arg=-lasan
+            -Clink-arg=-lubsan
+            -Cforce-frame-pointers=yes
+        # `| tee` without pipefail reports tee's exit status, so a failed build was scored
+        # as a successful step; the link has been broken and green since rust-lld became
+        # the default linker. ~keep
+        run: |
+          set -o pipefail
+          cargo build --locked -p ts-pack-cli --bin ts-pack 2>&1 | tee build.log
+          # libasan must be first in the initial library list or it disables itself at
+          # startup — the binary still carries __asan_ symbols, so only a runtime check
+          # can tell the difference. Resolved once here for every step that runs it. ~keep
+          echo "ASAN_RUNTIME=$(cc -print-file-name=libasan.so)" >>"$GITHUB_ENV"
 
       # The single most important check in this job: it proves the CFLAGS above actually
       # reached the compiler. If cc-rs ever stops forwarding CFLAGS, or build.rs starts
@@ -199,6 +215,33 @@ jobs:
             echo "::error::patch tree was not located; patched sources were not exercised"
             exit 1
           fi
+          # Symbol presence is necessary but NOT sufficient: when libasan is not first in
+          # the initial library list it prints a warning and disables itself, leaving a
+          # binary that still passes every `nm` check above and detects nothing. The only
+          # honest test is to plant a fault and require the sanitizer to catch it. ~keep
+          cat >/tmp/asan_selftest.c <<'C'
+          #include <stdlib.h>
+          #include <string.h>
+          int main(void) {
+              char *p = malloc(4);
+              memcpy(p, "12345678", 8);
+              int n = p[0];
+              free(p);
+              return n;
+          }
+          C
+          cc -fsanitize=address -fno-omit-frame-pointer -g /tmp/asan_selftest.c -o /tmp/asan_selftest
+          if LD_PRELOAD="$ASAN_RUNTIME" /tmp/asan_selftest 2>/tmp/asan_selftest.err; then
+            echo "::error::ASan positive control did NOT trap a deliberate heap overflow — the"
+            echo "::error::sanitizer is inert and this whole job proves nothing. Output follows:"
+            cat /tmp/asan_selftest.err
+            exit 1
+          fi
+          if ! grep -q 'heap-buffer-overflow' /tmp/asan_selftest.err; then
+            echo "::error::ASan positive control failed, but not with a heap-buffer-overflow report"
+            cat /tmp/asan_selftest.err
+            exit 1
+          fi
 
       # Each selected grammar must be linked in and reachable, otherwise the parse
       # sweep below would iterate over languages the binary cannot load and still
@@ -207,6 +250,7 @@ jobs:
         env:
           LANGS: ${{ steps.select.outputs.languages }}
           ASAN_OPTIONS: detect_leaks=0
+          LD_PRELOAD: ${{ env.ASAN_RUNTIME }}
         run: |
           set -euo pipefail
           target/debug/ts-pack list >linked.txt
@@ -229,6 +273,7 @@ jobs:
           LANGS: ${{ steps.select.outputs.languages }}
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=0:exitcode=42
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:exitcode=42
+          LD_PRELOAD: ${{ env.ASAN_RUNTIME }}
         run: |
           set -uo pipefail
           # Generated in Python rather than `printf | tr` so that backslash, quote and

--- a/.github/workflows/ci-sanitize.yaml
+++ b/.github/workflows/ci-sanitize.yaml
@@ -164,16 +164,23 @@ jobs:
           # not call `no_default_flags()`, so this is the supported injection point.
           # `-fno-sanitize-recover=all` turns a UBSan diagnosis into a hard abort rather
           # than a printed warning that a green exit code would hide. ~keep
-          CFLAGS: >-
+          # Target-scoped, NOT bare CFLAGS/RUSTFLAGS. With an explicit --target, cargo builds
+          # host build scripts with HOST settings, so they stay uninstrumented. Bare CFLAGS
+          # instruments every cc-rs crate in the graph including ring and zstd-sys, whose
+          # objects then land in a build script that cargo executes mid-build — and an
+          # instrumented binary run without the ASan runtime preloaded aborts on startup,
+          # failing the build before any grammar is ever parsed. ~keep
+          CFLAGS_x86_64_unknown_linux_gnu: >-
             -fsanitize=address,undefined
             -fno-sanitize-recover=all
             -fno-omit-frame-pointer
             -fno-common
             -g
+          CC_x86_64_unknown_linux_gnu: cc
           # rustc links with `-nodefaultlibs`, which suppresses exactly the libraries the
           # `-fsanitize=` driver flag exists to add, so the sanitizer runtimes have to be
           # named explicitly or the link fails on undefined __asan_/__ubsan_ symbols. ~keep
-          RUSTFLAGS: >-
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
             -Clink-arg=-fsanitize=address,undefined
             -Clink-arg=-lasan
             -Clink-arg=-lubsan
@@ -183,7 +190,7 @@ jobs:
         # the default linker. ~keep
         run: |
           set -o pipefail
-          cargo build --locked -p ts-pack-cli --bin ts-pack 2>&1 | tee build.log
+          cargo build --locked --target x86_64-unknown-linux-gnu -p ts-pack-cli --bin ts-pack 2>&1 | tee build.log
           # libasan must be first in the initial library list or it disables itself at
           # startup — the binary still carries __asan_ symbols, so only a runtime check
           # can tell the difference. Resolved once here for every step that runs it. ~keep
@@ -197,7 +204,7 @@ jobs:
       - name: Assert the binary is actually instrumented
         run: |
           set -euo pipefail
-          BIN=target/debug/ts-pack
+          BIN=target/x86_64-unknown-linux-gnu/debug/ts-pack
           test -x "$BIN" || { echo "::error::$BIN was not produced"; exit 1; }
           if ! nm -C "$BIN" 2>/dev/null | grep -q '__asan_'; then
             echo "::error::$BIN contains no __asan_ symbols — sanitizer flags did not take effect"
@@ -253,7 +260,7 @@ jobs:
           LD_PRELOAD: ${{ env.ASAN_RUNTIME }}
         run: |
           set -euo pipefail
-          target/debug/ts-pack list >linked.txt
+          target/x86_64-unknown-linux-gnu/debug/ts-pack list >linked.txt
           missing=""
           for lang in $(echo "$LANGS" | tr ',' ' '); do
             grep -qw -- "$lang" linked.txt || missing="$missing $lang"
@@ -301,7 +308,7 @@ jobs:
           for lang in $(echo "$LANGS" | tr ',' ' '); do
             for f in $FILES; do
               runs=$((runs + 1))
-              target/debug/ts-pack parse "$f" --language "$lang" >/dev/null 2>sweep.err
+              target/x86_64-unknown-linux-gnu/debug/ts-pack parse "$f" --language "$lang" >/dev/null 2>sweep.err
               rc=$?
               if [ "$rc" = "$SANITIZER_EXIT_CODE" ] || grep -qE 'ERROR: (Address|Leak)Sanitizer|runtime error:' sweep.err; then
                 failures=$((failures + 1))

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1298,7 +1298,6 @@ jobs:
       - name: Run Java unit tests
         working-directory: packages/java
         run: mvn test
-        env:
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4146,14 +4146,20 @@ jobs:
           set -euo pipefail
           cd packages/go
 
-          # Map alef-emitted platform labels to .lib directory names.
+          # ~keep The .lib directory name IS the alef platform label — binding.go's cgo LDFLAGS
+          # ~keep (-L${SRCDIR}/.lib/linux-aarch64 …) and cmd/setup's platformDir() both derive it
+          # ~keep from src/publish/platform.rs::go_java_platform(). This map used to translate the
+          # ~keep labels into Go GOARCH spellings (linux-amd64, linux-arm64, …), which matched
+          # ~keep neither consumer: 5 of 6 platforms staged libraries into a directory cgo never
+          # ~keep searches, so the published module could not link without running cmd/setup first.
+          # ~keep Keep this an identity map. See #178 for the same drift on the Java side.
           declare -A PLATFORM_MAP=(
-            [linux-x86_64]="linux-amd64"
-            [linux-aarch64]="linux-arm64"
+            [linux-x86_64]="linux-x86_64"
+            [linux-aarch64]="linux-aarch64"
             [macos-arm64]="macos-arm64"
-            [macos-x86_64]="macos-amd64"
-            [windows-x86_64]="windows-amd64"
-            [windows-aarch64]="windows-arm64"
+            [macos-x86_64]="macos-x86_64"
+            [windows-x86_64]="windows-x86_64"
+            [windows-aarch64]="windows-aarch64"
           )
 
           shopt -s nullglob

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1134,6 +1134,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # ~keep `platform` becomes the `natives/<classifier>/` directory inside the JAR, and
+        # ~keep NativeLib.resolveNativesRid computes the name it looks for at runtime. That method is
+        # ~keep alef-generated from src/publish/platform.rs::go_java_platform(), which emits `aarch64`
+        # ~keep for every non-macOS ARM64 target and special-cases macOS to `arm64`. These values MUST
+        # ~keep match it exactly. Issue #178: they said `arm64`, the loader looked for `aarch64`, and
+        # ~keep the native core failed to load on every ARM64 Linux and Windows host.
         include:
           - os: ubuntu-latest
             label: linux-x86_64
@@ -1142,7 +1148,7 @@ jobs:
           - os: ubuntu-24.04-arm
             label: linux-aarch64
             target: aarch64-unknown-linux-gnu
-            platform: linux-arm64
+            platform: linux-aarch64
           - os: macos-latest
             label: macos-arm64
             target: aarch64-apple-darwin
@@ -1158,7 +1164,7 @@ jobs:
           - os: windows-11-arm
             label: windows-arm64
             target: aarch64-pc-windows-msvc
-            platform: windows-arm64
+            platform: windows-aarch64
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -1229,7 +1235,7 @@ jobs:
         with:
           artifacts-dir: artifacts/java-natives
           resources-dir: packages/java/src/main/resources/natives
-          required-classifiers: linux-x86_64 linux-arm64 macos-arm64 macos-x86_64 windows-x86_64 windows-arm64
+          required-classifiers: linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64 windows-x86_64 windows-aarch64
           lib-name: ts_pack_core_ffi
 
       - name: Build and package
@@ -1258,7 +1264,7 @@ jobs:
           # because the re-stage loop walked one dirname too far. Require each
           # expected classifier directory to be present individually so the
           # collapse-to-`native` regression cannot ship again.
-          REQUIRED_CLASSIFIERS="linux-x86_64 linux-arm64 macos-arm64 macos-x86_64 windows-x86_64 windows-arm64"
+          REQUIRED_CLASSIFIERS="linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64 windows-x86_64 windows-aarch64"
           missing=()
           for c in $REQUIRED_CLASSIFIERS; do
             if ! echo "$ENTRIES" | grep -qE "^natives/$c/(lib)?ts_pack_core_ffi\.(so|dll|dylib)$"; then
@@ -2890,7 +2896,7 @@ jobs:
         run: |
           ARTIFACTS_DIR="artifacts/java-natives"
           RESOURCES_DIR="packages/java/src/main/resources/natives"
-          REQUIRED_CLASSIFIERS="linux-x86_64 linux-arm64 macos-arm64 macos-x86_64 windows-x86_64 windows-arm64"
+          REQUIRED_CLASSIFIERS="linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64 windows-x86_64 windows-aarch64"
           mkdir -p "$RESOURCES_DIR"
           # build-java-natives@v1 stages each lib at
           # `{output-dir}/native/{classifier}/{libfile}` and uploads that tree as

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2497,7 +2497,15 @@ jobs:
 
   publish-crates:
     name: Publish Rust crates
-    needs: [prepare, validate-versions, clone-vendors, check-registries, build-parser-sources, e2e-rust, finalize-github-release]
+    needs: [
+      prepare,
+      validate-versions,
+      clone-vendors,
+      check-registries,
+      build-parser-sources,
+      e2e-rust,
+      finalize-github-release,
+    ]
     if: |
       always() &&
       needs.prepare.outputs.release_crates == 'true' &&

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2497,7 +2497,7 @@ jobs:
 
   publish-crates:
     name: Publish Rust crates
-    needs: [prepare, validate-versions, clone-vendors, check-registries, build-parser-sources, e2e-rust]
+    needs: [prepare, validate-versions, clone-vendors, check-registries, build-parser-sources, e2e-rust, finalize-github-release]
     if: |
       always() &&
       needs.prepare.outputs.release_crates == 'true' &&
@@ -2505,6 +2505,7 @@ jobs:
       needs.validate-versions.result == 'success' &&
       needs.clone-vendors.result == 'success' &&
       needs.build-parser-sources.result == 'success' &&
+      needs.finalize-github-release.result == 'success' &&
       (fromJson(needs.check-registries.outputs.results).cratesio != 'true' || needs.prepare.outputs.force_republish == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -4258,12 +4259,117 @@ jobs:
           git push origin "refs/tags/packages/go/v${{ needs.prepare.outputs.version }}"
           echo "Go module tag pushed successfully"
 
+  finalize-github-release:
+    name: Publish GitHub release from draft
+    needs:
+      - prepare
+      - upload-parser-binaries
+      - upload-go-release
+      - upload-c-ffi-release
+      - update-swift-package-manifest
+      - stage-go-ffi-libraries
+      - upload-cli-release
+      - verify-binstall
+    if: |
+      always() &&
+      needs.prepare.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: xberg-io
+
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          fetch-depth: 0
+
+      # crates.io publishes are irreversible (yank-only) and ts-pack-core/build.rs
+      # downloads parsers.json + platform tarballs from THIS release by URL at
+      # `cargo build` time. Publishing crates.io before every asset it needs is
+      # uploaded AND the release is public is guaranteed breakage for any consumer
+      # resolving that version in the gap (#177). This job is the single gate
+      # publish-crates waits on: it checks every asset-upload job's actual RESULT
+      # (not just that it was scheduled — a bare `needs:` edge gates nothing once a
+      # job opens with always(), see the e2e-gate comment above), then publishes the
+      # draft release, so crates.io always goes last.
+      #
+      # upload-elixir-release and upload-php-pie-release are deliberately NOT in
+      # `needs:` here: build-elixir-nifs and build-php-extension already require
+      # publish-crates to succeed first (their release builds resolve the crate from
+      # crates.io, not from a workspace path), so those two asset uploads structurally
+      # happen AFTER crates.io publish. Requiring them here would be a real `needs:`
+      # cycle (finalize-github-release -> upload-elixir-release -> build-elixir-nifs ->
+      # publish-crates -> finalize-github-release), not just an ordering preference —
+      # GitHub Actions rejects the workflow outright if that edge is added. Elixir/PHP
+      # assets land on the release after it is already public, same as before this fix.
+      # ~keep
+      - name: Verify release assets are complete
+        if: needs.prepare.result == 'success'
+        env:
+          RESULT_UPLOAD_PARSERS: ${{ needs.upload-parser-binaries.result }}
+          RESULT_UPLOAD_GO: ${{ needs.upload-go-release.result }}
+          RESULT_UPLOAD_C_FFI: ${{ needs.upload-c-ffi-release.result }}
+          RESULT_SWIFT_MANIFEST: ${{ needs.update-swift-package-manifest.result }}
+          RESULT_STAGE_GO_FFI: ${{ needs.stage-go-ffi-libraries.result }}
+          RESULT_UPLOAD_CLI: ${{ needs.upload-cli-release.result }}
+          RESULT_VERIFY_BINSTALL: ${{ needs.verify-binstall.result }}
+          RELEASE_GO: ${{ needs.prepare.outputs.release_go }}
+          RELEASE_C_FFI: ${{ needs.prepare.outputs.release_c_ffi }}
+          RELEASE_SWIFT: ${{ needs.prepare.outputs.release_swift }}
+        run: |
+          failed=0
+
+          require_success() {
+            local name="$1" result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::Required release-asset job '$name' finished with '$result' — refusing to publish an incomplete release."
+              failed=1
+            fi
+          }
+
+          require_success_when_enabled() {
+            local name="$1" result="$2" enabled="$3"
+            if [[ "$enabled" == "true" && "$result" != "success" ]]; then
+              echo "::error::Release-asset job '$name' is enabled but finished with '$result' — refusing to publish an incomplete release."
+              failed=1
+            fi
+          }
+
+          require_success "parser-binaries" "$RESULT_UPLOAD_PARSERS"
+          require_success "cli-binaries" "$RESULT_UPLOAD_CLI"
+          require_success "binstall-verify" "$RESULT_VERIFY_BINSTALL"
+          require_success_when_enabled "go-ffi" "$RESULT_UPLOAD_GO" "$RELEASE_GO"
+          require_success_when_enabled "go-ffi-stage" "$RESULT_STAGE_GO_FFI" "$RELEASE_GO"
+          require_success_when_enabled "c-ffi" "$RESULT_UPLOAD_C_FFI" "$RELEASE_C_FFI"
+          require_success_when_enabled "swift-manifest" "$RESULT_SWIFT_MANIFEST" "$RELEASE_SWIFT"
+
+          if [[ "$failed" -eq 1 ]]; then
+            exit 1
+          fi
+          echo "All release-asset upload jobs are complete."
+
+      - name: Finalize release (publish from draft)
+        if: needs.prepare.result == 'success'
+        uses: xberg-io/actions/finalize-release@v1
+        with:
+          tag: ${{ needs.prepare.outputs.tag }}
+          go-module-path: ""
+          dry-run: ${{ needs.prepare.outputs.dry_run }}
+          token: ${{ steps.app-token.outputs.token }}
+
   release-finalize:
-    name: Finalize release
+    name: Aggregate release status
     needs:
       - prepare
       - validate-versions
       - check-registries
+      - finalize-github-release
       - upload-parser-binaries
       - upload-go-release
       - upload-c-ffi-release
@@ -4289,33 +4395,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        id: app-token
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          owner: xberg-io
-
-      - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
-          fetch-depth: 0
-
-      - name: Finalize release (publish from draft)
-        if: needs.prepare.result == 'success'
-        uses: xberg-io/actions/finalize-release@v1
-        with:
-          tag: ${{ needs.prepare.outputs.tag }}
-          go-module-path: ""
-          dry-run: ${{ needs.prepare.outputs.dry_run }}
-          token: ${{ steps.app-token.outputs.token }}
-
       - name: Aggregate release status
         if: always()
         env:
           CHECK_RESULTS: ${{ needs.check-registries.outputs.results }}
           RESULT_VALIDATE: ${{ needs.validate-versions.result }}
+          RESULT_FINALIZE_RELEASE: ${{ needs.finalize-github-release.result }}
           RESULT_PUBLISH_CRATES: ${{ needs.publish-crates.result }}
           RESULT_PUBLISH_PYPI: ${{ needs.publish-pypi.result }}
           RESULT_PUBLISH_NODE: ${{ needs.publish-node.result }}
@@ -4342,6 +4427,12 @@ jobs:
               echo "| version-check | **FAILED** |"
             else
               echo "| version-check | passed |"
+            fi
+
+            if [[ "$RESULT_FINALIZE_RELEASE" != "success" ]]; then
+              echo "| github-release | **FAILED** |"
+            else
+              echo "| github-release | published |"
             fi
 
             declare -A results

--- a/alef.toml
+++ b/alef.toml
@@ -231,6 +231,81 @@ path = "test_apps/zig/build.zig.zon"
 search = "download/v[0-9.]+/tree-sitter-language-pack-zig-v[0-9.]+"
 replace = "download/v{version}/tree-sitter-language-pack-zig-v{version}"
 
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.rust\]\s+name = "tree-sitter-language-pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.python\]\s+name = "tree-sitter-language-pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.node\]\s+name = "@xberg-io/tree-sitter-language-pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.go\]\s+module = "github.com/xberg-io/tree-sitter-language-pack/packages/go"\s+version = "v)[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.java\]\s+group_id = "io.xberg.treesitterlanguagepack"\s+artifact_id = "tree-sitter-language-pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.csharp\]\s+name = "TreeSitterLanguagePack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.ruby\]\s+name = "tree_sitter_language_pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.c\]\s+name = "tree-sitter-language-pack-ffi"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.wasm\]\s+name = "@xberg-io/tree-sitter-language-pack-wasm"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.elixir\]\s+name = "tree_sitter_language_pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.php\]\s+name = "xberg-io/tree-sitter-language-pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.zig\]\s+name = "tree_sitter_language_pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.swift\]\s+name = "TreeSitterLanguagePack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.dart\]\s+name = "tree_sitter_language_pack"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
+[[workspace.sync.text_replacements]]
+path = "alef.toml"
+search = '(\[crates\.e2e\.registry\.packages\.kotlin_android\]\s+name = "io.xberg.tslp.android:tree-sitter-language-pack-android"\s+version = ")[^"]*'
+replace = '${1}{version}'
+
 [workspace.poly]
 exclude = [
   "**/_generated/**",
@@ -1457,52 +1532,52 @@ github_repo = "https://github.com/xberg-io/tree-sitter-language-pack"
 
 [crates.e2e.registry.packages.rust]
 name = "tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.python]
 name = "tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.node]
 name = "@xberg-io/tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.go]
 module = "github.com/xberg-io/tree-sitter-language-pack/packages/go"
-version = "v1.14.3"
+version = "v1.15.0"
 
 [crates.e2e.registry.packages.java]
 group_id = "io.xberg.treesitterlanguagepack"
 artifact_id = "tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.csharp]
 name = "TreeSitterLanguagePack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.ruby]
 name = "tree_sitter_language_pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.c]
 name = "tree-sitter-language-pack-ffi"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.wasm]
 name = "@xberg-io/tree-sitter-language-pack-wasm"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.elixir]
 name = "tree_sitter_language_pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.php]
 name = "xberg-io/tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.zig]
 name = "tree_sitter_language_pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.zig.platform_hashes]
 "aarch64-apple-darwin" = "STALE_HASH_REGENERATE"
@@ -1513,15 +1588,15 @@ version = "1.14.3"
 
 [crates.e2e.registry.packages.swift]
 name = "TreeSitterLanguagePack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.dart]
 name = "tree_sitter_language_pack"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.packages.kotlin_android]
 name = "io.xberg.tslp.android:tree-sitter-language-pack-android"
-version = "1.14.3"
+version = "1.15.0"
 
 [crates.e2e.registry.run.jni]
 precondition = "command -v gradle >/dev/null 2>&1"

--- a/crates/ts-pack-core/language_definitions.json
+++ b/crates/ts-pack-core/language_definitions.json
@@ -133,7 +133,7 @@
   "brightscript": {
     "extensions": ["brs"],
     "repo": "https://github.com/ajdelcimmuto/tree-sitter-brightscript",
-    "rev": "253fdfaa23814cb46c2d5fc19049fa0f2f62c6da"
+    "rev": "0c534d56bb04778d0a3510bed5e720d1fe15cb76"
   },
   "bsl": {
     "abi_version": 14,

--- a/crates/ts-pack-core/tests/query_compilation.rs
+++ b/crates/ts-pack-core/tests/query_compilation.rs
@@ -29,8 +29,7 @@ const OVERLAY_TAGS_LANGUAGES: [&str; 9] =
 /// This list is enforced in BOTH directions: an entry that starts compiling fails the test just
 /// as loudly as an unlisted failure. A known-failures list nobody is forced to revisit is how a
 /// gate rots into a green light that checks nothing. ~keep
-const KNOWN_UPSTREAM_BROKEN: [(&str, QueryKind, &str); 5] = [
-    ("brightscript", QueryKind::Highlights, "upstream added the `(m) @keyword` query line and the grammar.js `m` rule in one commit but never re-ran `tree-sitter generate`, so their committed parser has no `m` node"),
+const KNOWN_UPSTREAM_BROKEN: [(&str, QueryKind, &str); 4] = [
     ("flatbuffers", QueryKind::Highlights, "upstream typo: grammar.js defines `enum_val_decl`, the query says `enumval_decl`"),
     ("hurl", QueryKind::Highlights, "upstream renamed the option field to `option_key:` and wrote the query against `key:` in the same commit"),
     ("solidity", QueryKind::Highlights, "upstream query text is malformed s-expression syntax; vendored bytes are identical to upstream and no patch of ours touches it"),

--- a/e2e/rust/Cargo.lock
+++ b/e2e/rust/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.14.3"
+version = "1.15.0"
 dependencies = [
  "ahash",
  "cc",

--- a/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
+++ b/packages/ruby/ext/ts_pack_core_rb/native/Cargo.lock
@@ -607,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1109,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,7 +1161,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.13.2"
+version = "1.15.0"
 dependencies = [
  "ahash",
  "cc",
@@ -1139,6 +1176,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
  "tree-sitter",
  "ureq",
  "zstd",
@@ -1146,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "ts-pack-core-rb"
-version = "1.13.2"
+version = "1.15.0"
 dependencies = [
  "magnus",
  "rb-sys",

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -133,7 +133,7 @@
   "brightscript": {
     "extensions": ["brs"],
     "repo": "https://github.com/ajdelcimmuto/tree-sitter-brightscript",
-    "rev": "253fdfaa23814cb46c2d5fc19049fa0f2f62c6da"
+    "rev": "0c534d56bb04778d0a3510bed5e720d1fe15cb76"
   },
   "bsl": {
     "abi_version": 14,

--- a/test_apps/rust/Cargo.lock
+++ b/test_apps/rust/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,8 +284,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -384,6 +403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +533,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -648,6 +689,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -900,6 +947,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,14 +999,15 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.10.6"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ea50365fa89d5ba65651d1d5daab3eadd2e3684df2bd6352541929eaea19c2"
+checksum = "83bbaee31d8295927db82b08bca21f365edf56fc9753f1d1d0674d46a49bbe08"
 dependencies = [
  "ahash",
  "cc",
  "dirs",
  "fd-lock",
+ "getrandom 0.4.3",
  "libloading",
  "memchr",
  "serde",
@@ -937,6 +1016,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
  "tree-sitter",
  "ureq",
  "zstd",
@@ -944,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "tree_sitter_language_pack-e2e-rust"
-version = "1.10.6"
+version = "1.14.3"
 dependencies = [
  "serde_json",
  "tree-sitter-language-pack",
@@ -1034,6 +1114,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]


### PR DESCRIPTION
Three independent fixes, one commit each.

**Java (#178):** the build matrix packaged ARM64 natives as `linux-arm64`/`windows-arm64`, but `NativeLib.resolveNativesRid` — alef-generated from `go_java_platform()` — looks for `linux-aarch64`/`windows-aarch64`. The JAR had no directory the loader would ever open, so it fell through to `System.loadLibrary` and threw `UnsatisfiedLinkError` on every ARM64 Linux and Windows host. Aligned the matrix and both verification gates with the loader.

**Go:** the same drift, unreported. `PLATFORM_MAP` translated alef labels into GOARCH spellings, so 4 of the 5 directories `binding.go`'s cgo LDFLAGS search had nothing staged in them — only `macos-arm64` lined up. The published module could not link without running `cmd/setup` first. Made the map an identity map.

**brightscript:** upstream added the `m` rule and `(m) @keyword` in one commit without re-running `tree-sitter generate`, so the entire highlights query was rejected and the language had no highlighting at all. They have regenerated `src/`; pin fast-forwarded one commit and the `KNOWN_UPSTREAM_BROKEN` entry dropped (the gate enforces that list in both directions).

Verification: the classifier fix is checked by porting `resolveNativesRid` and diffing against the matrix — red on `main`, green here. The brightscript gate was run with `TSLP_LANGUAGES=brightscript`, since it passes vacuously with no grammars linked; restoring the entry makes it fail with "1 query listed in KNOWN_UPSTREAM_BROKEN now compile(s)".

No generated files touched — the ARM64 fixes are deliberately on the workflow side, which is not under the current generation freeze.